### PR TITLE
Increase row height for easier clicking on mobile devices

### DIFF
--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -64,6 +64,12 @@ limitations under the License.
         padding: 0.2em 0.5em;
         border: solid 1px #ccc;
       }
+      table tr td:first-child::after {
+        content: "";
+        display: inline-block;
+        vertical-align: top;
+        min-height: 30px;
+      }
       .path-separator {
         padding: 0 0.1em;
       }

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -64,12 +64,6 @@ limitations under the License.
         padding: 0.2em 0.5em;
         border: solid 1px #ccc;
       }
-      table tr td:first-child::after {
-        content: "";
-        display: inline-block;
-        vertical-align: top;
-        min-height: 30px;
-      }
       .path-separator {
         padding: 0 0.1em;
       }
@@ -81,6 +75,15 @@ limitations under the License.
         background-color: #fde2e3;
         margin-bottom: 1em;
         border-left: solid 4px #f47477;
+      }
+
+      @media (max-width: 800px) {
+        table tr td:first-child::after {
+          content: "";
+          display: inline-block;
+          vertical-align: top;
+          min-height: 30px;
+        }
       }
     </style>
 


### PR DESCRIPTION
On mobile devices, clicking on the individual tests/categories was quite hard. Increase the row height to 30px makes it a lot easier to click on it.