### PR TITLE
Remove the use of Firefox profile in configuration.

### DIFF
--- a/run/run.py
+++ b/run/run.py
@@ -168,7 +168,6 @@ def main(platform_id, platform, args, config):
         ]
         if platform['browser_name'] == 'firefox':
             command.append('--certutil-binary=certutil')
-            command.append('--prefs-root=%s' % config['firefox_prefs_root'])
 
     command.append('--log-mach=-')
     command.extend(['--log-wptreport', LOCAL_REPORT_FILEPATH])

--- a/run/running.example.ini
+++ b/run/running.example.ini
@@ -7,7 +7,6 @@ chrome_binary = /usr/bin/google-chrome-unstable
 chromedriver_binary = /usr/local/bin/chromedriver
 firefox_binary = $HOME/Downloads/firefox/firefox
 geckodriver_binary = /usr/local/bin/geckodriver
-firefox_prefs_root = $HOME/profiles
 wptd_prod_host = https://wptdashboard.appspot.com
 gs_results_bucket = wptd
 install_wptrunner = false


### PR DESCRIPTION
In #126 the move to using |wpt run| obsoleted the need for setting the
profile as it wpt makes sure the profile is setup correctly.