### PR TITLE
Fix documentation for installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You'll need to make sure that you have Python 2.7 installed. It is recommended t
 
 Run the following command
 ```sh
-  pip install -r requirements
+  pip install -r requirements.txt
 ```
 
 ### Running


### PR DESCRIPTION
This is a fixup of 18c9d0016a395324f2eb65f385f5a896c499f2fc where
the file extension was omitted. At least on macOS, it doesn't work.