### PR TITLE
Remove --webdriver-binary

### DIFF
--- a/run/run.py
+++ b/run/run.py
@@ -83,10 +83,8 @@ def main(platform_id, platform, args, config):
     if not platform.get('sauce'):
         if platform['browser_name'] == 'chrome':
             browser_binary = config['chrome_binary']
-            webdriver_binary = config['chromedriver_binary']
         elif platform['browser_name'] == 'firefox':
             browser_binary = config['firefox_binary']
-            webdriver_binary = config['geckodriver_binary']
 
         verify_browser_binary_version(platform, browser_binary)
         verify_os_name(platform)
@@ -161,7 +159,6 @@ def main(platform_id, platform, args, config):
             './wpt', 'run',
             platform['browser_name'],
             '--binary', browser_binary,
-            '--webdriver-binary', webdriver_binary,
         ]
         if args.path:
             command.insert(4, args.path)

--- a/run/running.example.ini
+++ b/run/running.example.ini
@@ -1,11 +1,9 @@
 [default]
 build_path = $HOME/wptdbuild
-wpt_path = $HOME/gh/w3c/web-platform-tests
-wptd_path = $HOME/gh/w3c/wptdashboard
+wpt_path = $HOME/web-platform-tests
+wptd_path = $HOME/wptdashboard
 chrome_binary = /usr/bin/google-chrome-unstable
-chromedriver_binary = /usr/local/bin/chromedriver
 firefox_binary = $HOME/Downloads/firefox/firefox
-geckodriver_binary = /usr/local/bin/geckodriver
 wptd_prod_host = https://wptdashboard.appspot.com
 gs_results_bucket = wptd
 secret = SECRET_UPLOAD_TOKEN_GOES_HERE_YOU_NEED_THIS_TO_CREATE_TEST_RESULTS


### PR DESCRIPTION
Via #testing, we were passing the wrong value to
--webdriver-binary for Geckodriver, causing webdriver tests
in Firefox to fail. Now that `wpt run` supports downloading
a webdriver binary itself, we can remove this option.

cc @AutomatedTester 