### PR TITLE
Remove upstreamed patch for sc metrics address

### DIFF
--- a/util/wpt.patch
+++ b/util/wpt.patch
@@ -16,18 +16,6 @@ index e422cfe..51de088 100644
  
      def init_timeout(self):
 diff --git a/tools/wptrunner/wptrunner/browsers/sauce.py b/tools/wptrunner/wptrunner/browsers/sauce.py
-index a2f29a4c54..3cd1d67802 100644
---- a/tools/wptrunner/wptrunner/browsers/sauce.py
-+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
-@@ -151,6 +151,7 @@ class SauceConnect():
-             "--no-remove-colliding-tunnels",
-             "--tunnel-identifier=%s" % self.sauce_tunnel_id,
-             "--readyfile=./sauce_is_ready",
-+            "--metrics-address=localhost:9876",
-             "--tunnel-domains",
-             "web-platform.test",
-             "*.web-platform.test"
-diff --git a/tools/wptrunner/wptrunner/browsers/sauce.py b/tools/wptrunner/wptrunner/browsers/sauce.py
 index a2f29a4..6280a0c 100644
 --- a/tools/wptrunner/wptrunner/browsers/sauce.py
 +++ b/tools/wptrunner/wptrunner/browsers/sauce.py


### PR DESCRIPTION
@bobholt FYI now that https://github.com/w3c/web-platform-tests/pull/7679 landed it's causing patches on WPT to fail. I'm going to land this and update all the bots.