### PR TITLE
Dockerize WPT runs & add Jenkins k8s specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,12 @@ matrix:
         - pycodestyle .
         - python -m unittest discover -p "*_test.py"
 
+    - language: python
+      python: 2.7
+      services:
+        - docker
+      script: ./ci_container.sh
+
     - language: go
       install:
         - go get -t ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM gcr.io/cloud-solutions-images/jenkins-k8s-slave
+
+USER root
+
+# Expose Sauce Connect port
+EXPOSE 4445
+
+RUN apt-get update
+
+# wpt run dependencies
+RUN apt-get install -y python-pip
+RUN pip install virtualenv
+RUN pip install 'requests==2.13.0'
+
+RUN apt-get install -y git
+
+# Needed for hosts_fixup
+RUN apt-get install -y sudo
+
+# Used for running FF and Chrome
+RUN apt-get install -y xvfb
+
+# Used for running FF
+RUN apt-get install -y \
+    libnss3-tools \
+    libgtk-3-common \
+    libdbus-glib-1-2
+
+RUN mkdir /wptdashboard
+ADD . /wptdashboard
+
+RUN chown -R jenkins:jenkins /wptdashboard

--- a/ci_container.sh
+++ b/ci_container.sh
@@ -1,0 +1,15 @@
+: '
+An end-to-end test of both local configurations (Chrome, FF),
+and remote (Edge, Safari).
+
+This script must pass in order for an image to be pushed
+to production for test runners to pull.
+'
+IMAGE_NAME=wptd-testrun-jenkins
+
+docker build -t "${IMAGE_NAME}" .
+
+docker run \
+  -p 4445:4445 \
+  --entrypoint "/bin/bash" "${IMAGE_NAME}" \
+  /wptdashboard/util/ci_container_inner.sh

--- a/docs/running-ops.md
+++ b/docs/running-ops.md
@@ -1,0 +1,15 @@
+# Running Operations Documentation
+
+## Push a new Docker image to the registry
+
+You must be logged into the `wptdashboard` project in `gcloud`. Be advised
+this is risky as all Jenkins builds pull and use this container.
+
+```sh
+LOCAL_NAME=wptd-testrun-jenkins
+IMAGE_NAME=gcr.io/wptdashboard/$LOCAL_NAME
+
+docker build -t $LOCAL_NAME .
+docker tag $LOCAL_NAME $IMAGE_NAME
+gcloud docker -- push $IMAGE_NAME
+```

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,3 @@
+The files in this directory are for setting up and managing the Kubernetes cluster that runs Jenkins.
+
+For more context, see the Jenkins on Container Engine [GCP guide](https://cloud.google.com/solutions/jenkins-on-container-engine).

--- a/k8s/jenkins.yaml
+++ b/k8s/jenkins.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jenkins
+  namespace: jenkins
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: master
+    spec:
+      containers:
+      - name: master
+        image: jenkins/jenkins:2.67
+        ports:
+        - containerPort: 8080
+        - containerPort: 50000
+        readinessProbe:
+          httpGet:
+            path: /login
+            port: 8080
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 2
+          failureThreshold: 5
+        env:
+        - name: JENKINS_OPTS
+          valueFrom:
+            secretKeyRef:
+              name: jenkins
+              key: options
+        volumeMounts:
+        - mountPath: /var/jenkins_home
+          name: jenkins-home
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1500Mi
+          requests:
+            cpu: 500m
+            memory: 1500Mi
+      volumes:
+      - name: jenkins-home
+        gcePersistentDisk:
+          pdName: jenkins-home
+          fsType: ext4
+          partition: 1

--- a/k8s/lb/ingress.yaml
+++ b/k8s/lb/ingress.yaml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: jenkins
+  namespace: jenkins
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - secretName: tls
+  backend:
+    serviceName: jenkins-ui
+    servicePort: 8080

--- a/k8s/options
+++ b/k8s/options
@@ -1,0 +1,1 @@
+--argumentsRealm.passwd.jenkins=CHANGE_ME --argumentsRealm.roles.jenkins=admin

--- a/k8s/service_jenkins.yaml
+++ b/k8s/service_jenkins.yaml
@@ -1,0 +1,27 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: jenkins-ui
+  namespace: jenkins
+spec:
+  type: NodePort
+  selector:
+    app: master
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: ui
+kind: Service
+apiVersion: v1
+metadata:
+  name: jenkins-discovery
+  namespace: jenkins
+spec:
+  selector:
+    app: master
+  ports:
+    - protocol: TCP
+      port: 50000
+      targetPort: 50000
+      name: slaves

--- a/run/jenkins.py
+++ b/run/jenkins.py
@@ -116,6 +116,21 @@ def main():
         ]
         if args['run_path']:
             command.insert(3, args['run_path'])
+    elif platform['browser_name'] == "firefox":
+        command = [
+            'xvfb-run', '--auto-servernum',
+            './wpt', 'run',
+            platform['browser_name'],
+            '--install-fonts',
+            '--install-browser',
+            '--yes',
+            '--log-mach=%s' % LOCAL_LOG_FILEPATH,
+            '--log-wptreport=%s' % LOCAL_REPORT_FILEPATH,
+            # temp fix for webRTC
+            '--setpref', 'media.navigator.streams.fake=true',
+        ]
+        if args['run_path']:
+            command.insert(5, args['run_path'])
     else:
         command = [
             'xvfb-run', '--auto-servernum',

--- a/run/jenkins.py
+++ b/run/jenkins.py
@@ -8,20 +8,21 @@ import time
 import re
 
 
+# For making instance-internal network requests for metadata.
+# See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
 METADATA_URL = 'http://metadata.google.internal/computeMetadata/v1'
 
 
 def main():
     # TODO after --install-browser verify browser
-    # version or change platform ID to correct browser version
-    # This can be done by running `wpt install firefox` and then verifying
+    #      version or change platform ID to correct browser version
+    #      This can be done by running `wpt install firefox` and then verifying
     # TODO report OS version when creating TestRun
     # TODO check out correct WPT revision
-
     # TODO convert these back into command line args. They're currently
-    # env vars due to an earlier change. They should be converted back.
-
+    #      env vars due to an earlier change. They should be converted back.
     # TODO break this file up into smaller, unit tested modules.
+    # TODO document how we use metadata
     args = {
         'prod_run': bool(os.environ.get('PROD_RUN', False)),
         'prod_wet_run': bool(os.environ.get('PROD_WET_RUN', False)),
@@ -180,7 +181,7 @@ def main():
     print('==================================================')
     print('Uploading results to gs://%s' % GS_RESULTS_BUCKET)
 
-    # TODO: change this from rsync to cp
+    # TODO(#80): change this from rsync to cp
     command = ['gsutil', '-m', '-h', 'Content-Encoding:gzip',
                'rsync', '-r', args['SHA'], 'gs://wptd/%s' % args['SHA']]
     return_code = subprocess.check_call(command, cwd=args['output_path'])

--- a/run/jenkins.py
+++ b/run/jenkins.py
@@ -1,0 +1,280 @@
+# This replaces run/run.py
+import json
+import gzip
+import os
+import requests
+import subprocess
+import time
+import re
+
+
+METADATA_URL = 'http://metadata.google.internal/computeMetadata/v1'
+
+
+def main():
+    # TODO after --install-browser verify browser
+    # version or change platform ID to correct browser version
+    # This can be done by running `wpt install firefox` and then verifying
+    # TODO report OS version when creating TestRun
+    # TODO check out correct WPT revision
+
+    # TODO convert these back into command line args. They're currently
+    # env vars due to an earlier change. They should be converted back.
+
+    # TODO break this file up into smaller, unit tested modules.
+    args = {
+        'prod_run': bool(os.environ.get('PROD_RUN', False)),
+        'prod_wet_run': bool(os.environ.get('PROD_WET_RUN', False)),
+        'SHA': os.environ.get('WPT_SHA'),
+        'sauce_from_metadata': bool(os.environ.get('SAUCE_FROM_METADATA')),
+        'sauce_key': os.environ.get('SAUCE_KEY', ''),
+        'sauce_user': os.environ.get('SAUCE_USER', ''),
+        'jenkins_job_name': os.environ.get('JOB_NAME'),
+        'wpt_path': os.environ.get('WPT_PATH'),
+        'wptd_path': '/wptdashboard',
+        'output_path': '/wptdout',
+
+        # Passing RUN_PATH will run a specific path in WPT (e.g. html)
+        'run_path': os.environ.get('RUN_PATH', ''),
+    }
+
+    # Arg validation
+    assert args['wpt_path'], '`WPT_PATH` env var required.'
+    assert not args['wpt_path'].endswith('/'), '`WPT_PATH` cannot end with /.'
+    assert len(args['SHA']) == 10, '`WPT_SHA` env var required.'
+
+    if args['prod_run'] or args['prod_wet_run']:
+        print 'Fetching upload_secret from GCE Metadata...'
+
+        url = '%s/project/attributes/upload_secret' % METADATA_URL
+        res = requests.get(url, headers={'Metadata-Flavor': 'Google'})
+        args['upload_secret'] = res.text
+        assert len(args['upload_secret']) == 64, (
+            'Metadata `upload_secret` must exist for prod runs.')
+
+    platform_id, platform = get_and_validate_platform(args['wptd_path'])
+
+    PROD_HOST = 'https://wptdashboard.appspot.com'
+    GS_RESULTS_BUCKET = 'wptd'
+    LOCAL_LOG_FILEPATH = '%s/wptd-testrun.log' % args['output_path']
+    LOCAL_REPORT_FILEPATH = "%s/wptd-%s-%s-report.log" % (
+        args['output_path'], args['SHA'], platform_id
+    )
+    SUMMARY_PATH = '%s/%s-summary.json.gz' % (args['SHA'], platform_id)
+    LOCAL_SUMMARY_GZ_FILEPATH = "%s/%s" % (args['output_path'], SUMMARY_PATH)
+    GS_RESULTS_FILEPATH_BASE = "%s/%s/%s" % (
+        args['output_path'], args['SHA'], platform_id
+    )
+    GS_HTTP_RESULTS_URL = 'https://storage.googleapis.com/%s/%s' % (
+        GS_RESULTS_BUCKET, SUMMARY_PATH
+    )
+
+    SUMMARY_FILENAME = '%s-%s-summary.json.gz' % (args['SHA'], platform_id)
+    SUMMARY_HTTP_URL = 'https://storage.googleapis.com/%s/%s' % (
+        GS_RESULTS_BUCKET, SUMMARY_FILENAME
+    )
+
+    if platform.get('sauce'):
+        if args['sauce_from_metadata']:
+            print 'Fetching Sauce creds from GCE metadata...'
+
+            for key in ('sauce_user', 'sauce_key'):
+                url = '%s/project/attributes/%s' % (METADATA_URL, key)
+                res = requests.get(url, headers={'Metadata-Flavor': 'Google'})
+                args[key] = res.text
+                assert args[key], 'Metadata key %s is empty.' % key
+
+        assert args['sauce_key'], 'SAUCE_KEY env var required'
+        assert args['sauce_user'], 'SAUCE_USER env var required'
+        SAUCE_TUNNEL_ID = '%s_%s' % (platform_id, int(time.time()))
+
+    assert len(args['SHA']) == 10, 'SHA must a WPT SHA[:10]'
+
+    # Hack because Sauce expects a different name
+    # Maybe just change it in browsers.json?
+    if platform['browser_name'] == 'edge':
+        sauce_browser_name = 'MicrosoftEdge'
+    else:
+        sauce_browser_name = platform['browser_name']
+    product = 'sauce:%s:%s' % (sauce_browser_name, platform['browser_version'])
+
+    patch_wpt(args['wptd_path'], args['wpt_path'], platform)
+
+    if platform.get('sauce'):
+        command = [
+            './wpt', 'run', product,
+            '--sauce-platform=%s' % platform['os_name'],
+            '--sauce-key=%s' % args['sauce_key'],
+            '--sauce-user=%s' % args['sauce_user'],
+            '--sauce-tunnel-id=%s' % SAUCE_TUNNEL_ID,
+            '--no-restart-on-unexpected',
+            '--processes=2',
+            '--run-by-dir=3',
+            '--log-mach=-',
+            '--log-wptreport=%s' % LOCAL_REPORT_FILEPATH,
+            '--install-fonts'
+        ]
+        if args['run_path']:
+            command.insert(3, args['run_path'])
+    else:
+        command = [
+            'xvfb-run', '--auto-servernum',
+            './wpt', 'run',
+            platform['browser_name'],
+            '--install-fonts',
+            '--install-browser',
+            '--yes',
+            '--log-mach=%s' % LOCAL_LOG_FILEPATH,
+            '--log-wptreport=%s' % LOCAL_REPORT_FILEPATH,
+        ]
+        if args['run_path']:
+            command.insert(5, args['run_path'])
+
+    return_code = subprocess.call(command, cwd=args['wpt_path'])
+
+    print('==================================================')
+    print('Finished WPT run')
+    print('Return code from wptrunner: %s' % return_code)
+
+    with open(LOCAL_REPORT_FILEPATH) as f:
+        report = json.load(f)
+
+    assert len(report['results']) > 0, (
+        '0 test results, something went wrong, stopping.')
+
+    summary = report_to_summary(report)
+
+    print('==================================================')
+    print('Writing summary.json.gz to local filesystem')
+    write_gzip_json(LOCAL_SUMMARY_GZ_FILEPATH, summary)
+    print('Wrote file %s' % LOCAL_SUMMARY_GZ_FILEPATH)
+
+    print('==================================================')
+    print('Writing individual result files to local filesystem')
+    for result in report['results']:
+        test_file = result['test']
+        filepath = '%s%s' % (GS_RESULTS_FILEPATH_BASE, test_file)
+        write_gzip_json(filepath, result)
+        print('Wrote file %s' % filepath)
+
+    if not (args['prod_run'] or args['prod_wet_run']):
+        print('==================================================')
+        print('Stopping here (set PROD_RUN env var to upload results).')
+        return
+
+    print('==================================================')
+    print('Uploading results to gs://%s' % GS_RESULTS_BUCKET)
+
+    # TODO: change this from rsync to cp
+    command = ['gsutil', '-m', '-h', 'Content-Encoding:gzip',
+               'rsync', '-r', args['SHA'], 'gs://wptd/%s' % args['SHA']]
+    return_code = subprocess.check_call(command, cwd=args['output_path'])
+    assert return_code == 0, 'gsutil rsync return code was not 0!'
+    print('Successfully uploaded!')
+    print('HTTP summary URL: %s' % GS_HTTP_RESULTS_URL)
+
+    print('==================================================')
+    print('Creating new TestRun in the dashboard...')
+    url = '%s/test-runs' % PROD_HOST
+
+    if args['prod_run']:
+        final_browser_name = platform['browser_name']
+    else:
+        # The PROD_WET_RUN is identical to PROD_RUN, however the
+        # browser name it creates will be prefixed by eval-,
+        # causing it to not show up in the dashboard.
+        final_browser_name = 'eval-%s' % platform['browser_name']
+
+    response = requests.post(url, params={
+            'secret': args['upload_secret']
+        },
+        data=json.dumps({
+            'browser_name': final_browser_name,
+            'browser_version': platform['browser_version'],
+            'os_name': platform['os_name'],
+            'os_version': platform['os_version'],
+            'revision': args['SHA'],
+            'results_url': GS_HTTP_RESULTS_URL
+        }
+    ))
+    if response.status_code == 201:
+        print('Run created!')
+    else:
+        print('There was an issue creating the TestRun.')
+
+    print('Response status code:', response.status_code)
+    print('Response text:', response.text)
+
+
+def patch_wpt(wptd_path, wpt_path, platform):
+    """Applies util/wpt.patch to WPT.
+
+    The patch is necessary to keep WPT running on long runs.
+    jeffcarp has a PR out with this patch:
+    https://github.com/w3c/web-platform-tests/pull/5774
+    """
+    with open('%s/util/wpt.patch' % wptd_path) as f:
+        patch = f.read()
+
+    # The --sauce-platform command line arg doesn't
+    # accept spaces, but Sauce requires them in the platform name.
+    # https://github.com/w3c/web-platform-tests/issues/6852
+    patch = patch.replace('__platform_hack__', '%s %s' % (
+        platform['os_name'], platform['os_version'])
+    )
+
+    p = subprocess.Popen(
+        ['git', 'apply', '-'], cwd=wpt_path, stdin=subprocess.PIPE
+    )
+    p.communicate(input=patch)
+
+
+def get_and_validate_platform(wptd_path):
+    """Validates testing platform ID against currently tested platforms."""
+    with open('%s/browsers.json' % wptd_path) as f:
+        browsers = json.load(f)
+
+    platform_id = os.environ['PLATFORM_ID']
+    assert platform_id, 'PLATFORM_ID env var required (keys in browsers.json)'
+    assert platform_id in browsers, 'PLATFORM_ID not found in browsers.json'
+    return platform_id, browsers.get(platform_id)
+
+
+def report_to_summary(wpt_report):
+    """Parses a wptreport log object into a file-wise summary."""
+    test_files = {}
+
+    for result in wpt_report['results']:
+        test_file = result['test']
+
+        # We expect wpt_report to output only one entry per test.
+        assert test_file not in test_files, (
+            'Assumption that each test_file only shows up once broken!')
+
+        if result['status'] in ('OK', 'PASS'):
+            test_files[test_file] = [1, 1]
+        else:
+            test_files[test_file] = [0, 1]
+
+        for subtest in result['subtests']:
+            if subtest['status'] == 'PASS':
+                test_files[test_file][0] += 1
+
+            test_files[test_file][1] += 1
+
+    return test_files
+
+
+def write_gzip_json(filepath, payload):
+    try:
+        os.makedirs(os.path.dirname(filepath))
+    except OSError:
+        pass
+
+    with gzip.open(filepath, 'wb') as f:
+        payload_str = json.dumps(payload)
+        f.write(payload_str)
+
+
+if __name__ == '__main__':
+    main()

--- a/util/ci_container_inner.sh
+++ b/util/ci_container_inner.sh
@@ -6,7 +6,7 @@ export WPT_PATH=/web-platform-tests
 
 git clone --depth 1 https://github.com/w3c/web-platform-tests $WPT_PATH
 
-sudo chown -R $(whoami):$(whoami) $HOME
+sudo chown -R $(id -u $USER):$(id -g $USER) $HOME
 
 source $WPT_PATH/tools/ci/lib.sh
 hosts_fixup

--- a/util/ci_container_inner.sh
+++ b/util/ci_container_inner.sh
@@ -1,0 +1,18 @@
+: '
+This file runs inside the testrun container
+in the context of CI.
+'
+export WPT_PATH=/web-platform-tests
+
+git clone --depth 1 https://github.com/w3c/web-platform-tests $WPT_PATH
+
+source $WPT_PATH/tools/ci/lib.sh
+hosts_fixup
+
+export BUILD_PATH=/wptdashboard
+# Run a small directory (4 tests)
+export RUN_PATH=battery-status
+export WPT_SHA=$(cd $WPT_PATH && git rev-parse HEAD | head -c 10)
+
+export PLATFORM_ID=firefox-57.0-linux
+python /wptdashboard/run/jenkins.py

--- a/util/ci_container_inner.sh
+++ b/util/ci_container_inner.sh
@@ -6,6 +6,8 @@ export WPT_PATH=/web-platform-tests
 
 git clone --depth 1 https://github.com/w3c/web-platform-tests $WPT_PATH
 
+sudo chown -R $(whoami):$(whoami) $HOME
+
 source $WPT_PATH/tools/ci/lib.sh
 hosts_fixup
 

--- a/util/wpt.patch
+++ b/util/wpt.patch
@@ -1,20 +1,3 @@
-diff --git a/tools/wptrunner/wptrunner/testrunner.py b/tools/wptrunner/wptrunner/testrunner.py
-index e422cfe..51de088 100644
---- a/tools/wptrunner/wptrunner/testrunner.py
-+++ b/tools/wptrunner/wptrunner/testrunner.py
-@@ -193,6 +193,12 @@ class BrowserManager(object):
-         return succeeded
- 
-     def send_message(self, command, *args):
-+        if not hasattr(self, 'command_queue'):
-+            self.logger.error('BrowserManager.send_message cannot send message because no command_queue exists')
-+            self.logger.error('Command, args:')
-+            self.logger.error((command, args))
-+            self.cleanup()
-+            return
-         self.command_queue.put((command, args))
- 
-     def init_timeout(self):
 diff --git a/tools/wptrunner/wptrunner/browsers/sauce.py b/tools/wptrunner/wptrunner/browsers/sauce.py
 index a2f29a4..6280a0c 100644
 --- a/tools/wptrunner/wptrunner/browsers/sauce.py


### PR DESCRIPTION
This PR introduces a number of big changes:

- Adds a `Dockerfile` for generating a container capable of running any browser of WPT we currently run
  - It does not bundle a version of FF, it uses `--install-browser`
  - Currently this does not include Chrome
  - The whole running setup is end-to-end tested in Travis CI (FF only for now)
- Adds Kubernetes specs (in `k8s/`) for setting up a Jenkins instance (https://ci.wpt.fyi)

Future work after this lands (I will make bugs for these):

- Get Chrome running in the container (this might involve writing `--install-browser` for Chrome)
- Delete `run/run.py` once Chrome support lands
- Further investigate sharding FF builds

More context around this work is described in this comment: https://github.com/w3c/wptdashboard/issues/164#issuecomment-341172569