### PR TITLE
Show data for test files which do not end in html or htm.

### DIFF
--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -219,7 +219,10 @@ limitations under the License.
       }
 
       _computePathIsATestFile (path) {
-        return path.endsWith('.html') || path.endsWith('.htm')
+        return path.endsWith('.html') || path.endsWith('.htm') ||
+               path.endsWith('.py') || path.endsWith('.svg') ||
+               path.endsWith('.xhtml') || path.endsWith('.xht') ||
+               path.endsWith('.xml')
       }
 
       _nodeSort (a, b) {


### PR DESCRIPTION
This fixes #147.