### PR TITLE
Add BrowserVersion, OSName, OSVersion indexes

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -18,3 +18,24 @@ indexes:
   - name: BrowserName
   - name: CreatedAt
     direction: desc
+- kind: TestRun
+  properties:
+  - name: BrowserName
+  - name: BrowserVersion
+  - name: CreatedAt
+    direction: desc
+- kind: TestRun
+  properties:
+  - name: BrowserName
+  - name: BrowserVersion
+  - name: OSName
+  - name: CreatedAt
+    direction: desc
+- kind: TestRun
+  properties:
+  - name: BrowserName
+  - name: BrowserVersion
+  - name: OSName
+  - name: OSVersion
+  - name: CreatedAt
+    direction: desc


### PR DESCRIPTION
https://github.com/w3c/wptdashboard/issues/161 - Need index for the hyphen-delimited behaviour of that path - worked locally since everything is indexed in the default setup.

e.g. Currently we are getting 500s on the following URL:
https://wpt.fyi/latest/chrome-63.0

