### PR TITLE
Docker + protos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 *.pyc
 run/running.ini
 .DS_Store
+run/protos/*_pb2.py
+bq-schema

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ install:
 
 script:
   - sh/ci_script.sh
+
+after_script:
+  - sh/ci_after_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-matrix:
-  include:
-    - language: node_js
-      node_js:
-        - "node"
+sudo: required
 
-    - language: python
-      python: 2.7
-      install: "pip install -r requirements.txt"
-      script:
-        - pycodestyle .
-        - python -m unittest discover -p "*_test.py"
+services:
+  - docker
 
-    - language: go
-      install:
-        - go get -t ./...
-        - go get -u github.com/golang/lint/golint
-      script:
-        - go test -v ./...
-        - $GOPATH/bin/golint -set_exit_status
+before_install:
+  - sh/ci_before_install.sh
+
+install:
+  - sh/ci_install.sh
+
+script:
+  - sh/ci_script.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /pip
 WORKDIR /pip
 RUN curl -o "get-pip.py" "https://bootstrap.pypa.io/get-pip.py" && \
   python "get-pip.py" "pip===9.0.1" && \
-  pip install requests==2.18.1 pycodestyle==2.3.1 google-cloud==0.26.1 protobuf==${PB_VERSION} && \
+  pip install requests==2.18.1 pycodestyle==2.3.1 iso8601==0.1.12 google-cloud==0.26.1 protobuf==${PB_VERSION} && \
   cd /  && \
   rm -rf /pip
 
@@ -32,6 +32,7 @@ WORKDIR /protoc
 RUN curl -L -o "protoc.zip" "https://github.com/google/protobuf/releases/download/v${PB_VERSION}/protoc-${PB_VERSION}-linux-x86_64.zip" && \
   unzip "protoc.zip" && \
   cp "bin/protoc" /usr/local/bin/ && \
+  chmod a+rx "/usr/local/bin/protoc" && \
   cd /  && \
   rm -rf /protoc
 
@@ -39,6 +40,7 @@ WORKDIR /
 RUN git clone "https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema.git" && \
   cd "protoc-gen-bq-schema" && \
   make && \
-  cp bin/protoc-gen-bq-schema /usr/local/bin/
+  cp "bin/protoc-gen-bq-schema" /usr/local/bin/ && \
+  chmod a+rx "/usr/local/bin/protoc-gen-bq-schema"
 
 RUN mkdir -p "/wptdashboard"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.8-jessie
+
+# Install pip 9.0.1
+RUN curl -o "get-pip.py" "https://bootstrap.pypa.io/get-pip.py" && \
+  python "get-pip.py" "pip===9.0.1" && \
+  rm "get-pip.py"
+
+# Mount code and install dependencies that it specifies
+ADD . /code
+WORKDIR /code
+RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,51 @@
 FROM golang:1.8-jessie
 
-# Install pip 9.0.1
+ARG PB_VERSION=3.4.0
+
+# Used by dev server shell script
+ENV WATCH_DIR="/protos"
+ENV PB_LIB="/protobuf/src"
+ENV PROTOS="/wptdashboard/protos"
+ENV BQ_LIB="/protoc-gen-bq-schema"
+ENV BQ_OUT="/wptdashboard/bq-schema"
+ENV PY_OUT="/wptdashboard/run/protos"
+
+RUN apt-get update && apt-get install --assume-yes --no-install-suggests --no-install-recommends unzip inotify-tools
+
+RUN mkdir /protobuf-fetch
+WORKDIR /protobuf-fetch
+RUN curl -L -o "protobuf.zip" "https://github.com/google/protobuf/archive/v${PB_VERSION}.zip" && \
+  unzip "protobuf.zip" -d / && \
+  mv "/protobuf-${PB_VERSION}" "/protobuf" && \
+  cd /  && \
+  rm -rf /protobuf-fetch
+
+RUN mkdir /pip
+WORKDIR /pip
 RUN curl -o "get-pip.py" "https://bootstrap.pypa.io/get-pip.py" && \
   python "get-pip.py" "pip===9.0.1" && \
-  rm "get-pip.py"
+  rm "get-pip.py" && \
+  cd /  && \
+  rm -rf /pip
+
+RUN mkdir /protoc
+WORKDIR /protoc
+RUN curl -L -o "protoc.zip" "https://github.com/google/protobuf/releases/download/v${PB_VERSION}/protoc-${PB_VERSION}-linux-x86_64.zip" && \
+  unzip "protoc.zip" && \
+  cp "bin/protoc" /usr/local/bin/ && \
+  cd /  && \
+  rm -rf /protoc
+
+WORKDIR /
+RUN git clone "https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema.git" && \
+  cd "protoc-gen-bq-schema" && \
+  make && \
+  make install
 
 # Mount code and install dependencies that it specifies
-ADD . /code
-WORKDIR /code
+# Assume client will bind mound code to /wptdashboard
+ADD . /wptdashboard
+WORKDIR /wptdashboard
 RUN pip install -r requirements.txt
+
+RUN mkdir "${WATCH_DIR}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV PROTOS="/wptdashboard/protos"
 ENV BQ_OUT="/wptdashboard/bq-schema"
 ENV PY_OUT="/wptdashboard/run/protos"
 
+RUN go get github.com/golang/lint/golint
 RUN apt-get update && apt-get install --assume-yes --no-install-suggests --no-install-recommends unzip inotify-tools
 
 RUN mkdir /protobuf-fetch

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,3 +45,5 @@ RUN git clone "https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema.git" 
   chmod a+rx "/usr/local/bin/protoc-gen-bq-schema"
 
 RUN mkdir -p "/wptdashboard"
+RUN ln -s "/wptdashboard" "/go/src/wptdashboard"
+WORKDIR /wptdashboard

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ FROM golang:1.8-jessie
 ARG PB_VERSION=3.4.0
 
 # Used by dev server shell script
-ENV WATCH_DIR="/protos"
 ENV PB_LIB="/protobuf/src"
-ENV PROTOS="/wptdashboard/protos"
 ENV BQ_LIB="/protoc-gen-bq-schema"
+ENV PROTOS="/wptdashboard/protos"
 ENV BQ_OUT="/wptdashboard/bq-schema"
 ENV PY_OUT="/wptdashboard/run/protos"
 
@@ -24,7 +23,7 @@ RUN mkdir /pip
 WORKDIR /pip
 RUN curl -o "get-pip.py" "https://bootstrap.pypa.io/get-pip.py" && \
   python "get-pip.py" "pip===9.0.1" && \
-  rm "get-pip.py" && \
+  pip install requests==2.18.1 pycodestyle==2.3.1 google-cloud==0.26.1 protobuf==${PB_VERSION} && \
   cd /  && \
   rm -rf /pip
 
@@ -40,12 +39,6 @@ WORKDIR /
 RUN git clone "https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema.git" && \
   cd "protoc-gen-bq-schema" && \
   make && \
-  make install
+  cp bin/protoc-gen-bq-schema /usr/local/bin/
 
-# Mount code and install dependencies that it specifies
-# Assume client will bind mound code to /wptdashboard
-ADD . /wptdashboard
-WORKDIR /wptdashboard
-RUN pip install -r requirements.txt
-
-RUN mkdir "${WATCH_DIR}"
+RUN mkdir -p "/wptdashboard"

--- a/protos/strawman.proto
+++ b/protos/strawman.proto
@@ -1,0 +1,24 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package w3c.wptdashboard;
+import "bq_table_name.proto";
+
+message Strawman {
+  option (gen_bq_schema.table_name) = "strawmen";
+
+  int32 straw = 1;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.18.1
 pycodestyle==2.3.1
 google-cloud==0.26.1
+protobuf==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-requests==2.18.1
-pycodestyle==2.3.1
-google-cloud==0.26.1
-protobuf==3.4.0

--- a/sh/ci_after_script.sh
+++ b/sh/ci_after_script.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+SH_DIR=$(readlink -f $(dirname "$0"))
+source "${SH_DIR}/logging.sh"
+WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
+
+cd "${WPTDASHBOARD_DIR}"
+
+info "Stopping and removing docker instance 'wptdashboard-instance'"
+docker stop wptdashboard-instance && docker rm wptdashboard-instance
+DOCKER_STATUS=${?}
+if [ "${DOCKER_STATUS}" != "0" ]; then
+  error "Docker stop-and-remove failed."
+else
+  info "Docker stop-and-remove complete."
+fi
+exit ${DOCKER_STATUS}

--- a/sh/ci_before_install.sh
+++ b/sh/ci_before_install.sh
@@ -8,5 +8,5 @@ WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
 cd "${WPTDASHBOARD_DIR}"
 
 docker build -t wptdashboard:0.1 .
-docker run --rm -d -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v "$(pwd)":/wptdashboard -u $(id -u $USER):$(id -g $USER) --name wptdashboard-instance wptdashboard:0.1 /wptdashboard/sh/watch.sh
+docker run -d -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v "$(pwd)":/wptdashboard -u $(id -u $USER):$(id -g $USER) --name wptdashboard-instance wptdashboard:0.1 /wptdashboard/sh/watch.sh
 docker ps -a

--- a/sh/ci_before_install.sh
+++ b/sh/ci_before_install.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+set -e
+
 SH_DIR=$(readlink -f $(dirname "$0"))
 WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
 
 cd "${WPTDASHBOARD_DIR}"
 
 docker build -t wptdashboard:0.1 .
-docker run --rm -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v "$(pwd)":/wptdashboard -u $(id -u $USER):$(id -g $USER) --name wptdashboard-instance wptdashboard:0.1 /wptdashboard/sh/watch.sh &
+docker run --rm -d -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v "$(pwd)":/wptdashboard -u $(id -u $USER):$(id -g $USER) --name wptdashboard-instance wptdashboard:0.1 /wptdashboard/sh/watch.sh
 docker ps -a

--- a/sh/ci_before_install.sh
+++ b/sh/ci_before_install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SH_DIR=$(readlink -f $(dirname "$0"))
+WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
+
+cd "${WPTDASHBOARD_DIR}"
+
+docker build -t wptdashboard:0.1 .
+docker run --rm -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v "$(pwd)":/wptdashboard -u $(id -u $USER):$(id -g $USER) --name wptdashboard-instance wptdashboard:0.1 /wptdashboard/sh/watch.sh
+docker ps -a

--- a/sh/ci_before_install.sh
+++ b/sh/ci_before_install.sh
@@ -6,5 +6,5 @@ WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
 cd "${WPTDASHBOARD_DIR}"
 
 docker build -t wptdashboard:0.1 .
-docker run --rm -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v "$(pwd)":/wptdashboard -u $(id -u $USER):$(id -g $USER) --name wptdashboard-instance wptdashboard:0.1 /wptdashboard/sh/watch.sh
+docker run --rm -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v "$(pwd)":/wptdashboard -u $(id -u $USER):$(id -g $USER) --name wptdashboard-instance wptdashboard:0.1 /wptdashboard/sh/watch.sh &
 docker ps -a

--- a/sh/ci_install.sh
+++ b/sh/ci_install.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
+set -e
+
 SH_DIR=$(readlink -f $(dirname "$0"))
-WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
 
-cd "${WPTDASHBOARD_DIR}"
-
-go get -t /wptdashboard/...
-go get -u github.com/golang/lint/golint
+"${SH_DIR}/exec.sh" go get -t /wptdashboard/...

--- a/sh/ci_install.sh
+++ b/sh/ci_install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SH_DIR=$(readlink -f $(dirname "$0"))
+WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
+
+cd "${WPTDASHBOARD_DIR}"
+
+go get -t /wptdashboard/...
+go get -u github.com/golang/lint/golint

--- a/sh/ci_install.sh
+++ b/sh/ci_install.sh
@@ -4,4 +4,4 @@ set -e
 
 SH_DIR=$(readlink -f $(dirname "$0"))
 
-"${SH_DIR}/exec.sh" go get -t /wptdashboard/...
+"${SH_DIR}/su_exec.sh" /bin/bash -c "cd /go/src/wptdashboard && go get -t ./..."

--- a/sh/ci_script.sh
+++ b/sh/ci_script.sh
@@ -5,6 +5,6 @@ set -e
 SH_DIR=$(readlink -f $(dirname "$0"))
 
 "${SH_DIR}/exec.sh" pycodestyle --exclude=*_pb2.py .
-"${SH_DIR}/exec.sh" python -m unittest discover -p "./*_test.py"
+"${SH_DIR}/exec.sh" python -m unittest discover -p '*_test.py'
 "${SH_DIR}/exec.sh" go test -v ./...
 "${SH_DIR}/exec.sh" golint -set_exit_status

--- a/sh/ci_script.sh
+++ b/sh/ci_script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SH_DIR=$(readlink -f $(dirname "$0"))
+WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
+
+cd "${WPTDASHBOARD_DIR}"
+
+pycodestyle .
+python -m unittest discover -p "/wptdashboard/*_test.py"
+go test -v ./...
+"${GOPATH}/bin/golint" -set_exit_status

--- a/sh/ci_script.sh
+++ b/sh/ci_script.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+set -e
+
 SH_DIR=$(readlink -f $(dirname "$0"))
 WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
 
-cd "${WPTDASHBOARD_DIR}"
-
-pycodestyle .
-python -m unittest discover -p "/wptdashboard/*_test.py"
-go test -v ./...
-"${GOPATH}/bin/golint" -set_exit_status
+"${SH_DIR}/exec.sh" pycodestyle /wptdashboard
+"${SH_DIR}/exec.sh" python -m unittest discover -p "/wptdashboard/*_test.py"
+"${SH_DIR}/exec.sh" go test -v /wptdashboard/...
+"${SH_DIR}/exec.sh" golint -set_exit_status

--- a/sh/ci_script.sh
+++ b/sh/ci_script.sh
@@ -3,9 +3,8 @@
 set -e
 
 SH_DIR=$(readlink -f $(dirname "$0"))
-WPTDASHBOARD_DIR=${WPTDASHBOARD_DIR:-$(readlink -f "${SH_DIR}/..")}
 
-"${SH_DIR}/exec.sh" pycodestyle /wptdashboard
-"${SH_DIR}/exec.sh" python -m unittest discover -p "/wptdashboard/*_test.py"
-"${SH_DIR}/exec.sh" go test -v /wptdashboard/...
+"${SH_DIR}/exec.sh" pycodestyle --exclude=*_pb2.py .
+"${SH_DIR}/exec.sh" python -m unittest discover -p "./*_test.py"
+"${SH_DIR}/exec.sh" go test -v ./...
 "${SH_DIR}/exec.sh" golint -set_exit_status

--- a/sh/dev.sh
+++ b/sh/dev.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+SH_DIR=$(readlink -f $(dirname "$0"))
+source "${SH_DIR}/logging.sh"
+WPTDASHBOARD_DIR=$(readlink -f "${SH_DIR}/..")
+
+# Create a docker instance:
+#
+# --rm                                    Auto-remove when stopped
+# -it                                     Interactive mode (Ctrl+c will halt instance)
+# -v /etc/{group|passwd}:ro               READ-ONLY mount of user/group info on host machine
+# -v "${WPTDASHBOARD_DIR}":/wptdashboard  Mount the repository
+# -u $(id -u $USER):$(id -g $USER)        Run as current user and group
+# --name wptdashboard-instance            Name the instance
+# wptdashboard:0.1                        Identify image to use
+# /wptdashboard/sh/watch.sh               Identify code to execute
+
+info "Creating docker instance for dev server"
+docker run --rm -it -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro \
+  -v "${WPTDASHBOARD_DIR}":/wptdashboard -u $(id -u $USER):$(id -g $USER) \
+  --name wptdashboard-instance wptdashboard:0.1 /wptdashboard/sh/watch.sh

--- a/sh/exec.sh
+++ b/sh/exec.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+SH_DIR=$(readlink -f $(dirname "$0"))
+source "${SH_DIR}/logging.sh"
+WPTDASHBOARD_DIR=$(readlink -f "${SH_DIR}/..")
+
+# Execute code in docker instance:
+#
+# -u $(id -u $USER):$(id -g $USER)  Run as current user and group
+# wptdashboard-instance             Name of instance (wptdashboard dev server)
+
+if ! docker exec -u $(id -u $USER):$(id -g $USER) \
+  wptdashboard-instance $1 $2 $3 $4 $5 $6 $7 $8 $9; then
+  error "Execute-in-docker failed. Is docker instance 'wptdashboard-instance' running?"
+fi

--- a/sh/logging.sh
+++ b/sh/logging.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+function verbose() {
+  printf "\n${GRAY}[  $(date +'%Y-%m-%d %H:%M:%S')  VERB  ]  $1${NC}\n"
+}
+
+function info() {
+  printf "\n${GREEN}[  $(date +'%Y-%m-%d %H:%M:%S')  INFO  ]  $1${NC}\n"
+}
+
+function warn() {
+  printf "\n${YELLOW}[  $(date +'%Y-%m-%d %H:%M:%S')  WARN  ]  $1${NC}\n"
+}
+
+function error() {
+  printf "\n${RED}[  $(date +'%Y-%m-%d %H:%M:%S')  ERRR  ]  $1${NC}\n"
+}

--- a/sh/su_exec.sh
+++ b/sh/su_exec.sh
@@ -6,15 +6,15 @@ WPTDASHBOARD_DIR=$(readlink -f "${SH_DIR}/..")
 
 # Execute code in docker instance:
 #
-# -u $(id -u $USER):$(id -g $USER)  Run as current user and group
-# wptdashboard-instance             Name of instance (wptdashboard dev server)
+# -u 0:0                 Run as root
+# wptdashboard-instance  Name of instance (wptdashboard dev server)
 
 EXEC_STR=""
 for ARG in "${@}"; do
   EXEC_STR+="\"${ARG}\" "
 done
-info "Execute-in-docker:  ${EXEC_STR}"
-docker exec -u $(id -u $USER):$(id -g $USER) wptdashboard-instance "${@}"
+info "Super-user execute-in-docker:  ${EXEC_STR}"
+docker exec -u 0:0 wptdashboard-instance "${@}"
 DOCKER_STATUS=${?}
 if [ "${DOCKER_STATUS}" != "0" ]; then
   error "Execute-in-docker failed. Is docker instance 'wptdashboard-instance' running?"

--- a/sh/watch.sh
+++ b/sh/watch.sh
@@ -2,7 +2,15 @@
 
 set -e
 
-WATCH_DIR=${WATCH_DIR:-"."}
+SH_DIR=$(readlink -f $(dirname "$0"))
+source "${SH_DIR}/logging.sh"
+
+function stop() {
+  warn "Recieved interrupt. Exiting..."
+}
+
+trap stop INT
+
 PB_LIB=${PB_LIB:-"../protobuf/src"}
 PROTOS=${PROTOS:-"./protos"}
 BQ_LIB=${BQ_LIB:-"../protoc-gen-bq-schema"}
@@ -12,21 +20,20 @@ PY_OUT=${PY_OUT:-"./run/protos"}
 mkdir -p "${BQ_OUT}"
 mkdir -p "${PY_OUT}"
 
-inotifywait -r -m -e close_write,moved_to,create,delete "${WATCH_DIR}" |
-  while read -r dir evts f; do
-    if [[ ${f} =~ [.]proto$ ]] && ! [[ ${f} =~ [#~] ]]; then
-      echo "[ INFO ] Proto file changed: ${dir}${f}"
-      if protoc -I"${PB_LIB}" -I"${BQ_LIB}" -I"${PROTOS}" \
-        --bq-schema_out="${BQ_OUT}" \
-        "${PROTOS}"/*.proto && \
-        protoc -I"${PB_LIB}" -I"${BQ_LIB}" -I"${PROTOS}" \
-        --python_out="${PY_OUT}" \
-        "${BQ_LIB}"/*.proto "${PROTOS}"/*.proto; then
-        echo "[ INFO ] Regen from protos"
+inotifywait -r -m -e close_write,moved_to,create,delete,modify "${PROTOS}" | \
+    while read -r DIR EVTS F; do
+      if [[ ${F} =~ [.]proto$ ]] && ! [[ ${F} =~ [#~] ]]; then
+        if protoc -I"${PB_LIB}" -I"${BQ_LIB}" -I"${PROTOS}" \
+          --bq-schema_out="${BQ_OUT}" \
+          "${PROTOS}"/*.proto && \
+          protoc -I"${PB_LIB}" -I"${BQ_LIB}" -I"${PROTOS}" \
+          --python_out="${PY_OUT}" \
+          "${BQ_LIB}"/*.proto "${PROTOS}"/*.proto; then
+          info "SUCCESS: Regen from protos"
+        else
+          error "FAILURE: Regen from protos failed"
+        fi
       else
-        echo "[ ERRR ] Regen from protos failed"
+        verbose "Non-proto file changed: ${DIR}${F}"
       fi
-    else
-      echo "[ VERB ] Non-proto file changed: ${dir}${f}"
-    fi
-  done
+    done

--- a/sh/watch.sh
+++ b/sh/watch.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+WATCH_DIR=${WATCH_DIR:-"."}
+PB_LIB=${PB_LIB:-"../protobuf/src"}
+PROTOS=${PROTOS:-"./protos"}
+BQ_LIB=${BQ_LIB:-"../protoc-gen-bq-schema"}
+BQ_OUT=${BQ_OUT:-"./bq-schema"}
+PY_OUT=${PY_OUT:-"./run/protos"}
+
+mkdir -p "${BQ_OUT}"
+mkdir -p "${PY_OUT}"
+
+inotifywait -r -m -e close_write,moved_to,create,delete "${WATCH_DIR}" |
+  while read -r dir evts f; do
+    if [[ ${f} =~ [.]proto$ ]] && ! [[ ${f} =~ [#~] ]]; then
+      echo "[ INFO ] Proto file changed: ${dir}${f}"
+      if protoc -I"${PB_LIB}" -I"${BQ_LIB}" -I"${PROTOS}" \
+        --bq-schema_out="${BQ_OUT}" \
+        "${PROTOS}"/*.proto && \
+        protoc -I"${PB_LIB}" -I"${BQ_LIB}" -I"${PROTOS}" \
+        --python_out="${PY_OUT}" \
+        "${BQ_LIB}"/*.proto "${PROTOS}"/*.proto; then
+        echo "[ INFO ] Regen from protos"
+      else
+        echo "[ ERRR ] Regen from protos failed"
+      fi
+    else
+      echo "[ VERB ] Non-proto file changed: ${dir}${f}"
+    fi
+  done

--- a/sh/watch.sh
+++ b/sh/watch.sh
@@ -6,7 +6,7 @@ SH_DIR=$(readlink -f $(dirname "$0"))
 source "${SH_DIR}/logging.sh"
 
 function stop() {
-  warn "Recieved interrupt. Exiting..."
+  warn "watch.sh: Recieved interrupt. Exiting..."
 }
 
 trap stop INT


### PR DESCRIPTION
This PR introduces a `Dockerfile` that loads dependencies for Go, Python, and protobuf support. The intention is that the `sh/` directory will eventually contain several short scripts using Docker as a local build and execution environment. As a "demo" of how this might be used, the PR includes a script for a simple protobuf development server:

```bash
$ /install/docker/on/host/machine
$ cd /path/to/wptdashboard
$ docker build -t wptdashboard:0.1 . # Build Docker image based on ./Dockerfile
$ docker run --rm -it \ # Create and run in interactive mode: instance that will auto-remove when it stops
    -v $(pwd):/wptdashboard \ # Mount (read/write): host path: $(pwd) VM path: /wptdashboard
    --name wptdashboard-instance \ # Name the instance
    wptdashboard:0.1 \ # Use the image just created
    /wptdashboard/sh/watch.sh # Run sh/watch.sh; the development server script
```
If you touch `.proto` files in `protos/`, the development server should log confirmation that it regenerated code from protobuf files.

If useful, we could deploy to test, staging, and production environments using the same Docker image. This would help ensure that issues are easily reproducible.