### PR TITLE
Add latest prod runs to populate task

### DIFF
--- a/populate_dev_data_handler.go
+++ b/populate_dev_data_handler.go
@@ -15,13 +15,18 @@
 package wptdashboard
 
 import (
-    "net/http"
-    "time"
+	"errors"
     "fmt"
+    "net/http"
+	"net/url"
+    "time"
 
     "google.golang.org/appengine"
     "google.golang.org/appengine/datastore"
+    "google.golang.org/appengine/urlfetch"
 )
+
+var ErrUseLastResponse = errors.New("net/http: use last response")
 
 // Create TestRun entities for local development and testing.
 // These point to JSON files stored in /static/.
@@ -66,6 +71,41 @@ func populateDevData(w http.ResponseWriter, r *http.Request) {
             ResultsURL: "/static/b952881825/safari-10-macos-10.12-sauce-summary.json.gz",
             CreatedAt: time.Now(),
         },
+    }
+
+    // Get the redirects, but don't follow them. Mimics http.ErrUseLastResponse (golang v1.7)
+    client := urlfetch.Client(ctx)
+    client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+        return ErrUseLastResponse
+    }
+
+    for _, browserName := range([]string {
+        "chrome",
+        "edge",
+        "firefox",
+        "safari",
+    }) {
+        jsonURL := "https://wpt.fyi/json?platform=" + browserName
+        resp, err := client.Head(jsonURL)
+
+		if urlError, ok := err.(*url.Error); !ok || urlError.Err != ErrUseLastResponse {
+			fmt.Fprintf(w, "Failed to fetch latest run for %s: %s\n", browserName, urlError.Error())
+			continue
+		}
+
+		latestURL, err := resp.Location()
+		if err != nil {
+            fmt.Fprintf(w, "Failed to read redirected location for %s: %s\n", jsonURL, err.Error())
+            continue
+        }
+
+        devData["prod-latest-" + browserName] = &TestRun{
+            BrowserName:    browserName,
+            BrowserVersion: "latest",
+            Revision:       "latest",
+            ResultsURL:     latestURL.String(),
+            CreatedAt:      time.Now(),
+        }
     }
 
     for key, testRun := range devData {

--- a/populate_dev_data_handler.go
+++ b/populate_dev_data_handler.go
@@ -15,10 +15,10 @@
 package wptdashboard
 
 import (
-	"errors"
+    "errors"
     "fmt"
     "net/http"
-	"net/url"
+    "net/url"
     "time"
 
     "google.golang.org/appengine"
@@ -36,40 +36,40 @@ func populateDevData(w http.ResponseWriter, r *http.Request) {
 
     devData := map[string]*TestRun{
         "dev-testrun-chrome-63": &TestRun{
-            BrowserName: "chrome",
+            BrowserName:    "chrome",
             BrowserVersion: "63.0",
-            OSName: "linux",
-            OSVersion: "3.16",
-            Revision: "b952881825",
-            ResultsURL: "/static/b952881825/chrome-63.0-linux-summary.json.gz",
-            CreatedAt: time.Now(),
+            OSName:         "linux",
+            OSVersion:      "3.16",
+            Revision:       "b952881825",
+            ResultsURL:     "/static/b952881825/chrome-63.0-linux-summary.json.gz",
+            CreatedAt:      time.Now(),
         },
         "dev-testrun-edge-15": &TestRun{
-            BrowserName: "edge",
+            BrowserName:    "edge",
             BrowserVersion: "15",
-            OSName: "windows",
-            OSVersion: "10",
-            Revision: "b952881825",
-            ResultsURL: "/static/b952881825/edge-15-windows-10-sauce-summary.json.gz",
-            CreatedAt: time.Now(),
+            OSName:         "windows",
+            OSVersion:      "10",
+            Revision:       "b952881825",
+            ResultsURL:     "/static/b952881825/edge-15-windows-10-sauce-summary.json.gz",
+            CreatedAt:      time.Now(),
         },
         "dev-testrun-firefox-57": &TestRun{
-            BrowserName: "firefox",
+            BrowserName:    "firefox",
             BrowserVersion: "57.0",
-            OSName: "linux",
-            OSVersion: "*",
-            Revision: "b952881825",
-            ResultsURL: "/static/b952881825/firefox-57.0-linux-summary.json.gz",
-            CreatedAt: time.Now(),
+            OSName:         "linux",
+            OSVersion:      "*",
+            Revision:       "b952881825",
+            ResultsURL:     "/static/b952881825/firefox-57.0-linux-summary.json.gz",
+            CreatedAt:      time.Now(),
         },
         "dev-testrun-safari-10": &TestRun{
-            BrowserName: "safari",
+            BrowserName:    "safari",
             BrowserVersion: "10",
-            OSName: "macos",
-            OSVersion: "10.12",
-            Revision: "b952881825",
-            ResultsURL: "/static/b952881825/safari-10-macos-10.12-sauce-summary.json.gz",
-            CreatedAt: time.Now(),
+            OSName:         "macos",
+            OSVersion:      "10.12",
+            Revision:       "b952881825",
+            ResultsURL:     "/static/b952881825/safari-10-macos-10.12-sauce-summary.json.gz",
+            CreatedAt:      time.Now(),
         },
     }
 
@@ -79,27 +79,28 @@ func populateDevData(w http.ResponseWriter, r *http.Request) {
         return errUseLastResponse
     }
 
-    for _, browserName := range([]string {
+    for _, browserName := range []string{
         "chrome",
         "edge",
         "firefox",
         "safari",
-    }) {
+    } {
+        // TODO(lukebjerring): Move wpt.fyi base URL to constant.
         jsonURL := "https://wpt.fyi/json?platform=" + browserName
         resp, err := client.Head(jsonURL)
 
-		if urlError, ok := err.(*url.Error); !ok || urlError.Err != errUseLastResponse {
-			fmt.Fprintf(w, "Failed to fetch latest run for %s: %s\n", browserName, urlError.Error())
-			continue
-		}
+        if urlError, ok := err.(*url.Error); !ok || urlError.Err != errUseLastResponse {
+            fmt.Fprintf(w, "Failed to fetch latest run for %s: %s\n", browserName, urlError.Error())
+            continue
+        }
 
-		latestURL, err := resp.Location()
-		if err != nil {
+        latestURL, err := resp.Location()
+        if err != nil {
             fmt.Fprintf(w, "Failed to read redirected location for %s: %s\n", jsonURL, err.Error())
             continue
         }
 
-        devData["prod-latest-" + browserName] = &TestRun{
+        devData["prod-latest-"+browserName] = &TestRun{
             BrowserName:    browserName,
             BrowserVersion: "latest",
             Revision:       "latest",

--- a/populate_dev_data_handler.go
+++ b/populate_dev_data_handler.go
@@ -26,7 +26,7 @@ import (
     "google.golang.org/appengine/urlfetch"
 )
 
-var ErrUseLastResponse = errors.New("net/http: use last response")
+var errUseLastResponse = errors.New("net/http: use last response")
 
 // Create TestRun entities for local development and testing.
 // These point to JSON files stored in /static/.
@@ -76,7 +76,7 @@ func populateDevData(w http.ResponseWriter, r *http.Request) {
     // Get the redirects, but don't follow them. Mimics http.ErrUseLastResponse (golang v1.7)
     client := urlfetch.Client(ctx)
     client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-        return ErrUseLastResponse
+        return errUseLastResponse
     }
 
     for _, browserName := range([]string {
@@ -88,7 +88,7 @@ func populateDevData(w http.ResponseWriter, r *http.Request) {
         jsonURL := "https://wpt.fyi/json?platform=" + browserName
         resp, err := client.Head(jsonURL)
 
-		if urlError, ok := err.(*url.Error); !ok || urlError.Err != ErrUseLastResponse {
+		if urlError, ok := err.(*url.Error); !ok || urlError.Err != errUseLastResponse {
 			fmt.Fprintf(w, "Failed to fetch latest run for %s: %s\n", browserName, urlError.Error())
 			continue
 		}


### PR DESCRIPTION
Re-attempt at https://github.com/w3c/wptdashboard/pull/187, which failed because it used a golang 1.7 feature. This PR is identical, but manually replicates the ErrUseLastResponse behaviour.