### PR TITLE
Add UI documentation starter

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,13 @@
+# UI Development
+
+The UI consists of base HTML templates served by the Go App Engine app in `templates/` and Polymer 2 components in `components/`.
+
+## UI Principles
+
+- The dashboard should not surface any overall metrics that compare complete runs of different browsers against each other.
+- Clean, uncluttered design.
+
+### More specifically
+
+- All pages should be interactable [within 1000ms](https://developers.google.com/web/fundamentals/performance/rail#load) and fully loaded within 2000ms on a good connection.
+- All fonts are over `15px`.


### PR DESCRIPTION
Via discussion in #188, I think having stated UI design principles would help when people are submitting patches. Having somewhere to point people with stated standards is useful.