### PR TITLE
Add a tool for diffing runs

### DIFF
--- a/util/diff_runs.py
+++ b/util/diff_runs.py
@@ -32,11 +32,11 @@ import math
 import os
 import sys
 import urllib3
-
 from urllib import urlencode
 from typing import List
 
 here = os.path.dirname(__file__)
+
 
 def main():
     args = parse_flags()  # type: argparse.Namespace

--- a/util/diff_runs.py
+++ b/util/diff_runs.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tool for pulling 2 results JSON blobs for given runs, and diffing the results.
+
+Example usage:
+./diff_runs.py \
+    --before=chrome@b952881825 \
+    --after=chrome@7a0cf8ade7
+"""
+
+import argparse
+import inspect
+import json
+import logging
+import math
+import os
+import urllib3
+
+from urllib import urlencode
+from typing import List
+
+
+here = os.path.dirname(__file__)
+
+
+def main():
+    args = parse_flags()  # type: argparse.Namespace
+
+    loggingLevel = getattr(logging, args.log.upper(), None)
+    logging.basicConfig(level=loggingLevel)
+    logger = logging.getLogger()
+
+    differ = RunDiffer(args, logger, Fetcher())
+    differ.diff()
+
+
+# Create an ArgumentParser for the flags we'll expect.
+def parse_flags():  # type: () -> argparse.Namespace
+    # Re-use the docs above as the --help output.
+    parser = argparse.ArgumentParser(description=inspect.cleandoc(__doc__))
+    desc = (
+        '{platform(s)}@{sha} where platform(s) is a comma separated list of '
+        'platforms, e.g. \'chrome,safari\', and sha is SHA[0:10] of the run '
+        'to compare against the initial run'
+    )
+    parser.add_argument(
+        '--before',
+        required=True,
+        type=PlatformsAtRevision.parse,
+        help=desc)
+    parser.add_argument(
+        '--after',
+        required=True,
+        type=PlatformsAtRevision.parse,
+        help=desc)
+    parser.add_argument(
+        '--log',
+        type=str,
+        default='INFO',
+        help='Log level to output')
+    namespace = parser.parse_args()
+
+    # Check the before and after platform lists have the same length.
+    if len(namespace.before.platforms) != len(namespace.after.platforms):
+        msg = ('Different number of platforms in before and after flags.\n'
+               '--before %s\n--after %s')
+
+        raise ValueError(msg
+                         % (namespace.before.platforms,
+                            namespace.after.platforms))
+
+    return namespace
+
+
+class PlatformsAtRevision(object):
+    def __init__(self, sha, platforms):  # type: (str, List[str]) -> None
+        self.sha = sha
+        self.platforms = platforms
+
+    @classmethod
+    def parse(cls, value):  # type: (str) -> PlatformsAtRevision
+        pieces = value.split('@')
+        sha = 'latest'
+        platforms = ['chrome', 'edge', 'firefox', 'safari']
+        if len(pieces) > 2:
+            raise ValueError(value)
+
+        if len(pieces) > 1:
+            sha = pieces[1]
+        elif len(pieces) > 0:
+            sha = pieces[0]
+
+        if len(pieces) > 1:
+            platforms = pieces[0].split(',')
+
+        return PlatformsAtRevision(sha, platforms)
+
+
+class RunDiffer(object):
+    def __init__(self,
+                 args,  # type: argparse.Namespace
+                 logger,  # type: logging.Logger
+                 fetcher  # type: Fetcher
+                 ):
+        self.args = args
+        self.logger = logger
+        self.fetcher = fetcher
+
+    def diff(self):
+        beforeSHA = self.args.before.sha  # type: str
+        afterSHA = self.args.after.sha  # type: str
+
+        for i in range(0, len(self.args.after.platforms)):
+            specBefore = '%s@%s' % (self.args.before.platforms[i],
+                                    self.args.before.sha)
+            specAfter = '%s@%s' % (self.args.after.platforms[i],
+                                   self.args.after.sha)
+            runBefore = self.fetcher.fetchResults(
+                beforeSHA, self.args.before.platforms[i])
+            runAfter = self.fetcher.fetchResults(
+                afterSHA, self.args.after.platforms[i])
+
+            if runBefore is None:
+                self.logger.warning('Failed to fetch %s' % specBefore)
+            if runAfter is None:
+                self.logger.warning('Failed to fetch %s' % specAfter)
+            if runBefore is None or runAfter is None:
+                continue
+
+            differences = 0
+            checked = 0
+            added = 0
+            removed = 0
+
+            for k in filter(lambda x: x not in runAfter, runBefore.keys()):
+                removed += 1
+
+            for test in runAfter.keys():
+                checked += 1
+
+                if test not in runBefore:
+                    added += 1
+                    continue
+
+                resultAfter = runAfter[test]
+                resultBefore = runBefore[test]
+
+                passingDelta = resultAfter[0] - resultBefore[0]
+                totalDelta = resultAfter[1] - resultBefore[1]
+
+                if totalDelta > 0:
+                    self.logger.info('%s has %d new tests (total)'
+                                     % (test, totalDelta))
+                elif totalDelta < 0:
+                    self.logger.info('%s has %d removed tests (total)')
+
+                if passingDelta < 0:
+                    self.logger.warning('%s has %d new failures'
+                                        % (test, math.fabs(passingDelta)))
+                elif passingDelta > 0:
+                    self.logger.info('%s has %d new passes'
+                                     % (test, passingDelta))
+
+                delta = math.fabs(totalDelta) + math.fabs(passingDelta)
+                logging.debug('%s has %d differences (%s vs %s)'
+                              % (test,
+                                 passingDelta,
+                                 resultAfter,
+                                 resultBefore))
+                differences += delta
+
+            self.logger.info(
+                'Finished diff of %s and %s with %d differences in %d tests'
+                % (specBefore, specAfter, differences, checked))
+            if (added > 0):
+                self.logger.info('%d tests ran in %s but not in %s'
+                                 % (added, specAfter, specBefore))
+            if (removed > 0):
+                self.logger.info('%d tests ran in %s but not in %s'
+                                 % (removed, specBefore, specAfter))
+
+
+class Fetcher(object):
+    '''Placeholder for stubbing 'fetchResults' for the unit tests.'''
+
+    def __init__(self):
+        self.pool = urllib3.PoolManager()
+
+    def fetchResults(self, sha, platform):
+        '''Fetch a python object representing the test run results JSON for the
+        given sha/platform spec. '''
+        # type: (str, str) -> object
+
+        encodedArgs = urlencode({'sha': sha, 'platform': platform})
+        url = 'https://wpt.fyi/json?' + encodedArgs
+
+        response = self.pool.request('GET', url, redirect=False)
+
+        if response.status // 100 != 3:
+            logging.warning(
+                'Got unexpected non-redirect result %d for url %s'
+                % (response.status, url))
+            return None
+
+        loadedUrl = response.headers['location']
+        response = self.pool.request('GET', loadedUrl)
+
+        if response.status != 200:
+            logging.warning('Failed to fetch %s' % (url))
+            return None
+
+        logging.debug('Processing JSON from %s' % (url))
+        return json.loads(response.data.decode('utf-8'))
+
+
+if __name__ == '__main__':
+    main()

--- a/util/diff_runs_test.py
+++ b/util/diff_runs_test.py
@@ -1,0 +1,66 @@
+import argparse
+import logging
+import mock
+import unittest
+
+from diff_runs import Fetcher, RunDiffer, PlatformsAtRevision
+
+
+class DiffRunTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_args = mock.Mock(spec=argparse.Namespace)
+        self.mock_fetcher = mock.Mock(spec=Fetcher)
+        self.mock_logger = mock.Mock(spec=logging.Logger)
+
+        self.differ = RunDiffer(
+            self.mock_args, self.mock_logger, self.mock_fetcher)
+
+    def test_fetch_failure(self):
+        self.mock_args.after = PlatformsAtRevision.parse("chrome@latest")
+        self.mock_args.before = PlatformsAtRevision.parse("chrome@0123456789")
+        self.mock_fetcher.fetchResults.return_value = None
+
+        self.differ.diff()
+
+        self.mock_logger.warning.assert_called()
+        self.mock_logger.info.assert_not_called()
+
+    def test_no_difference(self):
+        self.mock_args.after = PlatformsAtRevision.parse("chrome@latest")
+        self.mock_args.before = PlatformsAtRevision.parse("chrome@0123456789")
+        self.mock_fetcher.fetchResults.return_value = {
+            '/mock/path.html': [1, 1],
+            '/mock/path_2.html': [3, 5],
+        }
+
+        self.differ.diff()
+
+        logged = self.mock_logger.info.call_args[0][0]
+        self.assertIn('0 differences', logged)
+        self.assertIn('2 tests', logged)
+
+    def test_one_difference(self):
+        self.mock_args.after = PlatformsAtRevision.parse("chrome@latest")
+        self.mock_args.before = PlatformsAtRevision.parse("chrome@0123456789")
+
+        def results(sha, platform):
+            if sha == 'latest':
+                return {
+                    '/mock/path.html': [0, 1]
+                }
+            if sha == '0123456789':
+                return {
+                    '/mock/path.html': [1, 1]
+                }
+        self.mock_fetcher.fetchResults.side_effect = results
+
+        self.differ.diff()
+
+        logged = self.mock_logger.info.call_args[0][0]
+        self.assertIn('1 differences', logged)
+        self.assertIn('1 tests', logged)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/util/diff_runs_test.py
+++ b/util/diff_runs_test.py
@@ -1,3 +1,19 @@
+#!/usr/bin/env python
+
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import logging
 import mock
@@ -23,8 +39,9 @@ class DiffRunTestCase(unittest.TestCase):
 
         self.differ.diff()
 
-        self.mock_logger.warning.assert_called()
-        self.mock_logger.info.assert_not_called()
+        # 2 failed-fetch warnings, one 'Diffing . and ." info
+        self.assertEqual(self.mock_logger.warning.call_count, 2)
+        self.mock_logger.info.assert_called_once()
 
     def test_no_difference(self):
         self.mock_args.after = PlatformsAtRevision.parse("chrome@latest")

--- a/util/requirements.txt
+++ b/util/requirements.txt
@@ -1,0 +1,4 @@
+urllib3==1.22
+typing==3.6.2
+protobuf==3.4.0
+mock==2.0.0

--- a/util/requirements.txt
+++ b/util/requirements.txt
@@ -1,4 +1,4 @@
-urllib3==1.22
-typing==3.6.2
-protobuf==3.4.0
+certifi==2017.11.5
 mock==2.0.0
+typing==3.6.2
+urllib3[secure]==1.21.1


### PR DESCRIPTION
Simple number diffing for 2 different runs, leveraging the wpt.fyi/json endpoint.

Will be nice to improve this to also have some test path filters, etc.