### PR TITLE
Add test paths filtering to diff tool

### DIFF
--- a/util/diff_runs.py
+++ b/util/diff_runs.py
@@ -32,6 +32,7 @@ import math
 import os
 import sys
 import urllib3
+from itertools import ifilter
 from urllib import urlencode
 from typing import List
 
@@ -81,6 +82,12 @@ def parse_flags():  # type: () -> argparse.Namespace
         type=str,
         default='INFO',
         help='Log level to output')
+    parser.add_argument(
+        'tests',
+        type=str,
+        nargs='*',
+        metavar='test',
+        help='Test paths to filter by')
     namespace = parser.parse_args()
 
     # Check the before and after platform lists have the same length.
@@ -143,6 +150,9 @@ class RunDiffer(object):
             runAfter = self.fetcher.fetchResults(
                 afterSHA, self.args.after.platforms[i])
 
+            self.cull_ignored_tests(runBefore, self.args.tests)
+            self.cull_ignored_tests(runAfter, self.args.tests)
+
             self.logger.info('Diffing %s and %s...' % (specBefore, specAfter))
 
             if runBefore is None:
@@ -177,7 +187,8 @@ class RunDiffer(object):
                     self.logger.info('%s has %d new tests (total)'
                                      % (test, totalDelta))
                 elif totalDelta < 0:
-                    self.logger.info('%s has %d removed tests (total)')
+                    self.logger.info('%s has %d removed tests (total)'
+                                     % (test, math.fabs(totalDelta)))
 
                 if passingDelta < 0:
                     self.logger.warning('%s has %d new failures'
@@ -204,6 +215,22 @@ class RunDiffer(object):
                 self.logger.info('%d tests ran in %s but not in %s'
                                  % (removed, specBefore, specAfter))
 
+    def cull_ignored_tests(self, results, testWhitelist):
+        if testWhitelist is None or len(testWhitelist) < 1:
+            return
+
+        # Cull tests that aren't whitelisted.
+        culled = 0
+        keys = results.keys()
+        tests = len(keys)
+        for key in keys:
+            def match(x): return key.startswith(x)
+            if next(ifilter(match, testWhitelist), None) is None:
+                culled += 1
+                del results[key]
+        self.logger.debug(
+            'Culled %d ignored tests of %d total' % (culled, tests))
+
 
 class Fetcher(object):
     '''Fetcher is a placeholder class which wraps request-logic, for stubbing
@@ -217,8 +244,8 @@ class Fetcher(object):
     def fetchResults(self, sha, platform):
         '''Fetch a python object representing the test run results JSON for the
         given sha/platform spec. '''
-        # type: (str, str) -> object
-        # Note that the object's keys are the test paths, and values are an
+        # type: (str, str) -> dict
+        # Note that the dict's keys are the test paths, and values are an
         # array of [pass_count, total_test_count].
         # For example JSON output, see https://wpt.fyi/json?platform=chrome
 

--- a/util/diff_runs_test.py
+++ b/util/diff_runs_test.py
@@ -26,6 +26,8 @@ class DiffRunTestCase(unittest.TestCase):
 
     def setUp(self):
         self.mock_args = mock.Mock(spec=argparse.Namespace)
+        self.mock_args.tests = []
+
         self.mock_fetcher = mock.Mock(spec=Fetcher)
         self.mock_logger = mock.Mock(spec=logging.Logger)
 
@@ -77,6 +79,28 @@ class DiffRunTestCase(unittest.TestCase):
         logged = self.mock_logger.info.call_args[0][0]
         self.assertIn('1 differences', logged)
         self.assertIn('1 tests', logged)
+
+    def test_cull_ignored_tests_dir(self):
+        results = {
+            '/css/foo.html': [1, 1],
+            '/css/bar.html': [1, 1],
+            '/html/baz.html': [0, 1]
+        }
+        tests = ['/css/']
+        self.differ.cull_ignored_tests(results, tests)
+        self.assertIn('/css/foo.html', results)
+        self.assertIn('/css/bar.html', results)
+        self.assertNotIn('/html/baz.html', results)
+
+    def test_cull_ignored_tests_specific_test(self):
+        results = {
+            '/css/foo.html': [1, 1],
+            '/css/bar.html': [1, 1],
+        }
+        tests = ['/css/foo.html']
+        self.differ.cull_ignored_tests(results, tests)
+        self.assertIn('/css/foo.html', results)
+        self.assertNotIn('/css/bar.html', results)
 
 
 if __name__ == '__main__':

--- a/util/diff_runs_test.py
+++ b/util/diff_runs_test.py
@@ -59,6 +59,26 @@ class DiffRunTestCase(unittest.TestCase):
         self.assertIn('0 differences', logged)
         self.assertIn('2 tests', logged)
 
+    def test_removes_all(self):
+        self.mock_args.after = PlatformsAtRevision.parse("chrome@latest")
+        self.mock_args.before = PlatformsAtRevision.parse("chrome@0123456789")
+
+        def results(sha, platform):
+            if sha == 'latest':
+                return {}
+            if sha == '0123456789':
+                return {
+                    '/mock/path.html': [1, 1],
+                    '/mock/path2.html': [1, 2]
+                }
+        self.mock_fetcher.fetchResults.side_effect = results
+
+        self.differ.diff()
+
+        logged = self.mock_logger.info.call_args[0][0]
+        self.assertIn('2 tests ran in', logged)
+        self.assertIn('but not in', logged)
+
     def test_one_difference(self):
         self.mock_args.after = PlatformsAtRevision.parse("chrome@latest")
         self.mock_args.before = PlatformsAtRevision.parse("chrome@0123456789")


### PR DESCRIPTION
Allows specific path prefixes, which is useful for comparing results of 2 runs for a given folder.
e.g. `util/diff_runs.py --before=chrome@latest --after=safari@latest /css/css-images/`