### PR TITLE
Persist loaded browser names

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -36,8 +36,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := appengine.NewContext(r)
 	var browserNames []string
-	browserNames, err = GetBrowserNames()
-	if err != nil {
+	if browserNames, err = GetBrowserNames(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/test_handler.go
+++ b/test_handler.go
@@ -17,11 +17,9 @@ package wptdashboard
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
-	"sort"
 )
 
 // This handler is responsible for all pages that display test results.
@@ -86,27 +84,4 @@ func GetRunSHA(r *http.Request) (runSHA string, err error) {
 		runSHA = runParam
 	}
 	return runSHA, err
-}
-
-// GetBrowserNames loads, parses and returns the set of names of browsers
-// which are to be included (flagged as initially_loaded in the JSON).
-// TODO(lukebjerring): Persist in memory.
-func GetBrowserNames() (browserNames []string, err error) {
-	var bytes []byte
-	if bytes, err = ioutil.ReadFile("browsers.json"); err != nil {
-		return nil, err
-	}
-
-	var browsers map[string]Browser
-	if err = json.Unmarshal(bytes, &browsers); err != nil {
-		return nil, err
-	}
-
-	for _, browser := range browsers {
-		if browser.InitiallyLoaded {
-			browserNames = append(browserNames, browser.BrowserName)
-		}
-	}
-	sort.Strings(browserNames)
-	return browserNames, nil
 }

--- a/test_run_handler.go
+++ b/test_run_handler.go
@@ -23,7 +23,6 @@ import (
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
-	"sort"
 )
 
 func testRunHandler(w http.ResponseWriter, r *http.Request) {
@@ -82,30 +81,14 @@ func handlePost(w http.ResponseWriter, r *http.Request) {
 
 func handleGet(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
-	var bytes []byte
 	var err error
-	var browsers map[string]Browser
-
-	if bytes, err = ioutil.ReadFile("browsers.json"); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if err = json.Unmarshal(bytes, &browsers); err != nil {
+	var browserNames []string
+	if browserNames, err = GetBrowserNames(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	baseQuery := datastore.NewQuery("TestRun").Order("-CreatedAt").Limit(100)
-	var browserNames []string
-
-	for _, browser := range browsers {
-		if browser.InitiallyLoaded {
-			browserNames = append(browserNames, browser.BrowserName)
-		}
-	}
-	sort.Strings(browserNames)
-
 	runs := make(map[string][]TestRun)
 	for _, browserName := range browserNames {
 		var testRunResults []TestRun

--- a/util.go
+++ b/util.go
@@ -1,0 +1,49 @@
+package wptdashboard
+
+import (
+	"io/ioutil"
+	"encoding/json"
+	"sort"
+)
+
+var browsers map[string]Browser
+var browserNames []string
+
+// GetBrowsers loads, parses and returns the set of names of browsers
+// which are to be included (flagged as initially_loaded in the JSON).
+func GetBrowsers() (map[string]Browser, error) {
+	if browsers != nil {
+		return browsers, nil
+	}
+	var bytes []byte
+	var err error
+	if bytes, err = ioutil.ReadFile("browsers.json"); err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(bytes, &browsers); err != nil {
+		return nil, err
+	}
+	return browsers, nil
+}
+
+// GetBrowserNames returns an alphabetically-ordered array of the names
+// of the browsers returned by GetBrowsers.
+func GetBrowserNames() ([]string, error) {
+	if browserNames != nil {
+		return browserNames, nil
+	}
+
+	var browsers map[string]Browser
+	var err error
+	if browsers, err = GetBrowsers(); err != nil {
+		return nil, err
+	}
+	for _, browser := range browsers {
+		if browser.InitiallyLoaded {
+			browserNames = append(browserNames, browser.BrowserName)
+		}
+	}
+	sort.Strings(browserNames)
+	return browserNames, nil
+}


### PR DESCRIPTION
Moves 'GetBrowserNames' into a util.go for re-use, and persists the result in memory.