### PR TITLE
Filter non-200 fetches

### DIFF
--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -237,7 +237,7 @@ limitations under the License.
             const sha = pieces.length > 1 ? pieces[1] : 'latest'
             const url = `/api/run?browser=${browser}&sha=${sha}`
             const response = await window.fetch(url)
-            if (response.status != 200) {
+            if (response.status !== 200) {
               return Promise.resolve()
             }
             return response.json()

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -230,15 +230,19 @@ limitations under the License.
           this._refreshDisplayedNodes()
         }
 
-        const testRuns = await Promise.all(
+        const fetches = await Promise.all(
           this.testRunSpecs.map(async testRun => {
             const pieces = testRun.split('@')
             const browser = pieces[0]
             const sha = pieces.length > 1 ? pieces[1] : 'latest'
             const url = `/api/run?browser=${browser}&sha=${sha}`
             const response = await window.fetch(url)
+            if (response.status != 200) {
+              return Promise.resolve()
+            }
             return response.json()
           }))
+        const testRuns = fetches.filter(e => e)  // Filter unresolved fetches.
 
         const testFileResults = await Promise.all(
           testRuns.map(async json => this._fetchResults(json.results_url))


### PR DESCRIPTION
The test_handler.go produces a spec list for a given sha, and doesn't actually check whether each browser exists for the given sha (which is determined by the /api/run returning a 404).

Fixes https://github.com/w3c/wptdashboard/issues/232