### PR TITLE
Revert wpt-results to supporting test-runs being inlined.

### DIFF
--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -194,12 +194,12 @@ limitations under the License.
             type: Boolean,
             computed: '_computeIsLatest(sha)'
           },
-          // ['browser@sha', ...] specs for the runs to load using /api/run
-          // e.g. ['chrome@latest', 'edge@latest', 'firefox@latest', 'safari@latest']
-          testRunSpecs: {
+          // URLs to load to get the TestRun JSON
+          testRunResources: {
             type: Array
           },
-          // Fetched + parsed JSON blobs for the runs loaded (by their specs, above)
+          // TestRuns JSON objects, either fetched + parsed (from their source URLs, above),
+          // or initially dumped inline in the test-runs attribute.
           testRuns: {
             type: Array
           },
@@ -230,18 +230,19 @@ limitations under the License.
           this._refreshDisplayedNodes()
         }
 
-        const testRuns = await Promise.all(
-          this.testRunSpecs.map(async testRun => {
-            const pieces = testRun.split('@')
-            const browser = pieces[0]
-            const sha = pieces.length > 1 ? pieces[1] : 'latest'
-            const url = `/api/run?browser=${browser}&sha=${sha}`
-            const response = await window.fetch(url)
-            return response.json()
-          }))
+        // Fetch the TestRun JSON if it's not dumped inline.
+        if (!this.testRuns) {
+          const testRuns = await Promise.all(
+            this.testRunResources.map(async url => {
+              const response = await window.fetch(url)
+              return response.json()
+            }))
+          this.testRuns = testRuns
+        }
 
+        // Fetch the results JSON for the TestRuns
         const testFileResults = await Promise.all(
-          testRuns.map(async json => this._fetchResults(json.results_url))
+          this.testRuns.map(async json => this._fetchResults(json.results_url))
         )
 
         testFileResults.forEach(result => {
@@ -255,7 +256,6 @@ limitations under the License.
           })
         })
 
-        this.testRuns = testRuns
         this._refreshDisplayedNodes()
       }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
 <div id="content">
   {{ template "_header.html" }}
   <div>
-    <wpt-results test-run-specs="{{ .TestRunSpecs }}" sha="{{ .SHA }}"></wpt-results>
+    <wpt-results test-run-resources="{{ .TestRunSources }}" sha="{{ .SHA }}"></wpt-results>
   </div>
 </div>
 {{ template "_ga.html" }}

--- a/test_handler.go
+++ b/test_handler.go
@@ -60,9 +60,9 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	const sourceUrl = `/api/run?browser=%s&sha=%s`
+	const sourceURL = `/api/run?browser=%s&sha=%s`
 	for _, browserName := range browserNames {
-		testRunSources = append(testRunSources, fmt.Sprintf(sourceUrl, browserName, runSHA))
+		testRunSources = append(testRunSources, fmt.Sprintf(sourceURL, browserName, runSHA))
 	}
 
 	testRunSourcesBytes, err := json.Marshal(testRunSources)

--- a/test_handler.go
+++ b/test_handler.go
@@ -42,7 +42,7 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var testRunSpecs []string
+	var testRunSources []string
 	var browserNames []string
 	browserNames, err = GetBrowserNames()
 	if err != nil {
@@ -60,21 +60,22 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	const sourceUrl = `/api/run?browser=%s&sha=%s`
 	for _, browserName := range browserNames {
-		testRunSpecs = append(testRunSpecs, fmt.Sprintf("%s@%s", browserName, runSHA))
+		testRunSources = append(testRunSources, fmt.Sprintf(sourceUrl, browserName, runSHA))
 	}
 
-	testRunSpecsBytes, err := json.Marshal(testRunSpecs)
+	testRunSourcesBytes, err := json.Marshal(testRunSources)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	data := struct {
-		TestRunSpecs string
-		SHA          string
+		TestRunSources string
+		SHA            string
 	}{
-		string(testRunSpecsBytes),
+		string(testRunSourcesBytes),
 		runSHA,
 	}
 


### PR DESCRIPTION
Continues to use the resources from /api/run, but allows the component to have the runs specified as inline JSON (as was the previous impl), which will be needed for re-using the component.