### PR TITLE
Add shared results polymer base class

### DIFF
--- a/components/results.html
+++ b/components/results.html
@@ -1,0 +1,56 @@
+<!--
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+
+<dom-module id="wpt-results-base">
+    <script>
+      class ResultsBase extends window.Polymer.Element {
+        static get is() { return 'wpt-results-base' }
+
+        static get properties() {
+          return {
+            // ['browser@sha', ...] specs for the runs to load using /api/run
+            // e.g. ['chrome@latest', 'edge@latest', 'firefox@latest', 'safari@latest']
+            testRunSpecs: {
+              type: Array
+            },
+            // Fetched + parsed JSON blobs for the runs loaded (by their specs, above)
+            testRuns: {
+              type: Array
+            },
+          }
+        }
+
+        async connectedCallback() {
+          super.connectedCallback()
+          if (!this.testRuns) {
+            this.testRuns = await Promise.all(
+              this.testRunSpecs.map(async testRun => {
+              const pieces = testRun.split('@')
+              const browser = pieces[0]
+              const sha = pieces.length > 1 ? pieces[1] : 'latest'
+              const url = `/api/run?browser=${browser}&sha=${sha}`
+              const response = await window.fetch(url)
+              return response.json()
+            }))
+          }
+        }
+      }
+
+      window.customElements.define(ResultsBase.is, ResultsBase)
+    </script>
+</dom-module>

--- a/components/results.html
+++ b/components/results.html
@@ -19,9 +19,9 @@ limitations under the License.
 <dom-module id="wpt-results-base">
     <script>
       class ResultsBase extends window.Polymer.Element {
-        static get is() { return 'wpt-results-base' }
+        static get is () { return 'wpt-results-base' }
 
-        static get properties() {
+        static get properties () {
           return {
             // ['browser@sha', ...] specs for the runs to load using /api/run
             // e.g. ['chrome@latest', 'edge@latest', 'firefox@latest', 'safari@latest']
@@ -31,22 +31,23 @@ limitations under the License.
             // Fetched + parsed JSON blobs for the runs loaded (by their specs, above)
             testRuns: {
               type: Array
-            },
+            }
           }
         }
 
-        async connectedCallback() {
+        async connectedCallback () {
           super.connectedCallback()
           if (!this.testRuns) {
             this.testRuns = await Promise.all(
               this.testRunSpecs.map(async testRun => {
-              const pieces = testRun.split('@')
-              const browser = pieces[0]
-              const sha = pieces.length > 1 ? pieces[1] : 'latest'
-              const url = `/api/run?browser=${browser}&sha=${sha}`
-              const response = await window.fetch(url)
-              return response.json()
-            }))
+                const pieces = testRun.split('@')
+                const browser = pieces[0]
+                const sha = pieces.length > 1 ? pieces[1] : 'latest'
+                const url = `/api/run?browser=${browser}&sha=${sha}`
+                const response = await window.fetch(url)
+                return response.json()
+              })
+            )
           }
         }
       }

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -77,6 +77,7 @@ limitations under the License.
   </template>
 
   <script>
+    /* global ResultsBase */
     class TestFileResults extends ResultsBase {
       static get is () { return 'test-file-results' }
 

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
 <link rel="import" href="results.html">

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -17,6 +17,7 @@ limitations under the License.
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="results.html">
 <link rel="import" href="test-run.html">
 
 <dom-module id="test-file-results">
@@ -76,17 +77,13 @@ limitations under the License.
   </template>
 
   <script>
-    class TestFileResults extends window.Polymer.Element {
+    class TestFileResults extends ResultsBase {
       static get is () { return 'test-file-results' }
 
       static get properties () {
         return {
-          testRuns: {
-            type: Array
-          },
           testFile: {
-            type: String,
-            observer: '_testFileChanged'
+            type: String
           },
           subtestNames: {
             type: Array,
@@ -95,12 +92,14 @@ limitations under the License.
         }
       }
 
-      connectedCallback () {
-        super.connectedCallback()
+      async connectedCallback () {
+        await super.connectedCallback()
         console.assert(this.testFile)
         console.assert(this.testFile[0] === '/')
         console.assert(this.testRuns)
         console.assert(this.testRuns.length > 0)
+
+        this.fetchTestFile()
       }
 
       async fetchTestFile () {
@@ -136,11 +135,6 @@ limitations under the License.
           return Promise.resolve(null)
         }
         return response.json()
-      }
-
-      _testFileChanged () {
-        this.subtestNames = []
-        this.fetchTestFile()
       }
 
       resultsURL (testRun, testFile) {

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
 <link rel="import" href="results.html">

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -17,6 +17,7 @@ limitations under the License.
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="results.html">
 <link rel="import" href="test-file-results.html">
 <link rel="import" href="test-run.html">
 
@@ -132,6 +133,7 @@ limitations under the License.
 
       <test-file-results
         test-runs="[[testRuns]]"
+        test-run-specs="[[testRunSpecs]]"
         test-file="[[path]]">
       </test-file-results>
     </template>
@@ -177,7 +179,7 @@ limitations under the License.
   </template>
 
   <script>
-    class WPTResults extends window.Polymer.Element {
+    class WPTResults extends ResultsBase {
       static get is () { return 'wpt-results' }
 
       static get properties () {
@@ -193,15 +195,6 @@ limitations under the License.
           isLatest: {
             type: Boolean,
             computed: '_computeIsLatest(sha)'
-          },
-          // ['browser@sha', ...] specs for the runs to load using /api/run
-          // e.g. ['chrome@latest', 'edge@latest', 'firefox@latest', 'safari@latest']
-          testRunSpecs: {
-            type: Array
-          },
-          // Fetched + parsed JSON blobs for the runs loaded (by their specs, above)
-          testRuns: {
-            type: Array
           },
           path: {
             type: String,
@@ -223,25 +216,15 @@ limitations under the License.
       }
 
       async connectedCallback () {
-        super.connectedCallback()
+        await super.connectedCallback()
 
         window.onpopstate = (event) => {
           this.path = window.location.pathname.replace(/(.+)(\/)$/, '$1')
           this._refreshDisplayedNodes()
         }
 
-        const testRuns = await Promise.all(
-          this.testRunSpecs.map(async testRun => {
-            const pieces = testRun.split('@')
-            const browser = pieces[0]
-            const sha = pieces.length > 1 ? pieces[1] : 'latest'
-            const url = `/api/run?browser=${browser}&sha=${sha}`
-            const response = await window.fetch(url)
-            return response.json()
-          }))
-
         const testFileResults = await Promise.all(
-          testRuns.map(async json => this._fetchResults(json.results_url))
+          this.testRuns.map(async json => this._fetchResults(json.results_url))
         )
 
         testFileResults.forEach(result => {
@@ -255,7 +238,6 @@ limitations under the License.
           })
         })
 
-        this.testRuns = testRuns
         this._refreshDisplayedNodes()
       }
 

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -179,6 +179,7 @@ limitations under the License.
   </template>
 
   <script>
+    /* global ResultsBase */
     class WPTResults extends ResultsBase {
       static get is () { return 'wpt-results' }
 


### PR DESCRIPTION
Fix for https://github.com/w3c/wptdashboard/issues/235, which is caused when the reload of an individual-results page does not trigger the (newly added) api fetch for the TestRun JSON.