### PR TITLE
Remove Google disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,6 @@ This doesn't work with some HTTPS tests. Also be advised that the server is not 
 - ECMAScript 6 compatibility table - https://kangax.github.io/compat-table/es6/
 - https://html5test.com/
 
-#### Disclaimer
-
-This is not an official Google product.
-
 # Appendix
 
 ## Terminology

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "wptdashboard",
   "devDependencies": {
     "standard": "*",
-    "eslint-plugin-html": "*"
+    "eslint-plugin-html": "*",
+    "eslint": "*"
   },
   "scripts": {
     "test": "standard --plugin html 'components/*.html'"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "wptdashboard",
   "devDependencies": {
     "standard": "*",
-    "eslint-plugin-html": "*",
-    "eslint": "*"
+    "eslint-plugin-html": "3.2.2",
   },
   "scripts": {
     "test": "standard --plugin html 'components/*.html'"


### PR DESCRIPTION
As this project is under the W3C umbrella now, we can remove this Google-specific disclaimer