### PR TITLE
Sort test-runs browsers alphabetically.

### DIFF
--- a/components/wpt-runs.html
+++ b/components/wpt-runs.html
@@ -135,7 +135,7 @@ limitations under the License.
             .map(entry => ({ sha: entry[0], runs: entry[1] }))
             .sort((a, b) => firstRunTime(a) < firstRunTime(b) ? 1 : -1)
         this.testResults = flattened
-        this.browsers = Array.from(browsers)
+        this.browsers = Array.from(browsers).sort()
       }
 
       _runClass (testRuns, browser) {


### PR DESCRIPTION
Currently wrong order due to using a set.