### PR TITLE
Migrate /test-runs POST to /api/runs POST

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -16,8 +16,10 @@ package wptdashboard
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
@@ -66,13 +68,23 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(testRunsBytes)
 }
 
-// apiTestRunHandler is responsible for emitting the test-run JSON a specific run,
+func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == "POST" {
+		apiTestRunPostHandler(w, r)
+	} else if r.Method == "GET" {
+		apiTestRunGetHandler(w, r)
+	} else {
+		http.Error(w, "This endpoint only supports GET and POST.", http.StatusMethodNotAllowed)
+	}
+}
+
+// apiTestRunGetHandler is responsible for emitting the test-run JSON a specific run,
 // identified by a named browser (platform) at a given SHA.
 //
 // URL Params:
 //     sha: SHA[0:10] of the repo when the test was executed (or 'latest')
 //     browser: Browser for the run (e.g. 'chrome', 'safari-10')
-func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
+func apiTestRunGetHandler(w http.ResponseWriter, r *http.Request) {
 	runSHA, err := ParseSHAParam(r)
 	if err != nil {
 		http.Error(w, "Invalid query params", http.StatusBadRequest)
@@ -118,6 +130,56 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write(testRunsBytes)
+}
+
+// apiTestRunPostHandler is responsible for handling TestRun submissions (via HTTP POST requests).
+// It asserts the presence of a required secret token, then saves the JSON blob to the Datastore.
+// See models.go for the JSON format expected.
+func apiTestRunPostHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	var err error
+
+	// Fetch pre-uploaded Token entity.
+	suppliedSecret := r.URL.Query().Get("secret")
+	tokenKey := datastore.NewKey(ctx, "Token", "upload-token", 0, nil)
+	var token Token
+	if err = datastore.Get(ctx, tokenKey, &token); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if suppliedSecret != token.Secret {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	var body []byte
+	if body, err = ioutil.ReadAll(r.Body); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var testRun TestRun
+	if err = json.Unmarshal(body, &testRun); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	testRun.CreatedAt = time.Now()
+
+	// Create a new TestRun out of the JSON body of the request.
+	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
+	if _, err := datastore.Put(ctx, key, &testRun); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var jsonOutput []byte
+	if jsonOutput, err = json.Marshal(testRun); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(jsonOutput)
+	w.WriteHeader(http.StatusCreated)
 }
 
 // getBrowserParam parses and validates the 'browser' param for the request.

--- a/api_handlers.go
+++ b/api_handlers.go
@@ -23,6 +23,7 @@ import (
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
+	"fmt"
 )
 
 // apiTestRunsHandler is responsible for emitting test-run JSON for all the runs at a given SHA.
@@ -149,7 +150,7 @@ func apiTestRunPostHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if suppliedSecret != token.Secret {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		http.Error(w, fmt.Sprintf("Invalid token '%s'", suppliedSecret), http.StatusUnauthorized)
 		return
 	}
 
@@ -161,7 +162,7 @@ func apiTestRunPostHandler(w http.ResponseWriter, r *http.Request) {
 
 	var testRun TestRun
 	if err = json.Unmarshal(body, &testRun); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "Failed to parse JSON: " + err.Error(), http.StatusBadRequest)
 		return
 	}
 	testRun.CreatedAt = time.Now()

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var templates = template.Must(template.ParseGlob("templates/*.html"))
 
 func init() {
 	http.HandleFunc("/tasks/populate-dev-data", populateDevData)
-	http.HandleFunc("/test-runs", testRunHandler)
+	http.HandleFunc("/test-runs", testRunsHandler)
 	http.HandleFunc("/about", aboutHandler)
 	http.HandleFunc("/api/runs", apiTestRunsHandler)
 	http.HandleFunc("/api/run", apiTestRunHandler)

--- a/populate_dev_data_handler.go
+++ b/populate_dev_data_handler.go
@@ -86,11 +86,14 @@ func populateDevData(w http.ResponseWriter, r *http.Request) {
 		"safari",
 	} {
 		// TODO(lukebjerring): Move wpt.fyi base URL to constant.
-		jsonURL := "https://wpt.fyi/json?platform=" + browserName
+		jsonURL := "https://wpt.fyi/results?platform=" + browserName
 		resp, err := client.Head(jsonURL)
 
-		if urlError, ok := err.(*url.Error); !ok || urlError.Err != errUseLastResponse {
-			fmt.Fprintf(w, "Failed to fetch latest run for %s: %s\n", browserName, urlError.Error())
+		if err == nil {
+			fmt.Fprintf(w, "Got unexpected non-redirect status %d for %s\n", resp.StatusCode, jsonURL)
+			continue
+		} else if urlError, ok := err.(*url.Error); !ok || urlError.Err != errUseLastResponse {
+			fmt.Fprintf(w, "Failed to fetch latest run for %s: %s\n", browserName, )
 			continue
 		}
 

--- a/populate_dev_data_handler.go
+++ b/populate_dev_data_handler.go
@@ -86,14 +86,18 @@ func populateDevData(w http.ResponseWriter, r *http.Request) {
 		"safari",
 	} {
 		// TODO(lukebjerring): Move wpt.fyi base URL to constant.
-		jsonURL := "https://wpt.fyi/results?platform=" + browserName
+		jsonURL := "https://wpt.fyi/json?platform=" + browserName
 		resp, err := client.Head(jsonURL)
+		if resp != nil {
+			defer resp.Body.Close()
+		}
 
+		if urlError, ok := err.(*url.Error); !ok || urlError.Err != errUseLastResponse {
+			fmt.Fprintf(w, "Failed to fetch latest run for %s: %s\n", browserName, )
+			continue
+		}
 		if err == nil {
 			fmt.Fprintf(w, "Got unexpected non-redirect status %d for %s\n", resp.StatusCode, jsonURL)
-			continue
-		} else if urlError, ok := err.(*url.Error); !ok || urlError.Err != errUseLastResponse {
-			fmt.Fprintf(w, "Failed to fetch latest run for %s: %s\n", browserName, )
 			continue
 		}
 

--- a/test_run_handler.go
+++ b/test_run_handler.go
@@ -16,70 +16,25 @@ package wptdashboard
 
 import (
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
 	"net/http"
-	"time"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
-func testRunHandler(w http.ResponseWriter, r *http.Request) {
+// testRunsHandler handles GET/POST requests to /test-runs
+func testRunsHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "POST" {
-		handlePost(w, r)
+		// /test-runs is the legacy POST endpoint, migrated to /api/runs and left to avoid breakages.
+		apiTestRunPostHandler(w, r)
 	} else if r.Method == "GET" {
-		handleGet(w, r)
+		handleTestRunGet(w, r)
 	} else {
 		http.Error(w, "This endpoint only supports GET and POST.", http.StatusMethodNotAllowed)
 	}
 }
 
-func handlePost(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
-	var err error
-
-	// Fetch pre-uploaded Token entity.
-	suppliedSecret := r.URL.Query().Get("secret")
-	tokenKey := datastore.NewKey(ctx, "Token", "upload-token", 0, nil)
-	var token Token
-	if err = datastore.Get(ctx, tokenKey, &token); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if suppliedSecret != token.Secret {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
-		return
-	}
-
-	var body []byte
-	if body, err = ioutil.ReadAll(r.Body); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	var testRun TestRun
-	if err = json.Unmarshal(body, &testRun); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	testRun.CreatedAt = time.Now()
-
-	fmt.Fprintf(w, "got... %v", testRun)
-
-	// Create a new TestRun out of the JSON body of the request.
-	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
-	if _, err := datastore.Put(ctx, key, &testRun); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	fmt.Fprintf(w, "Successfully created TestRun... %v", testRun)
-	w.WriteHeader(http.StatusCreated)
-}
-
-func handleGet(w http.ResponseWriter, r *http.Request) {
+func handleTestRunGet(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 	var err error
 	var browserNames []string

--- a/test_run_handler.go
+++ b/test_run_handler.go
@@ -26,7 +26,8 @@ import (
 // testRunsHandler handles GET/POST requests to /test-runs
 func testRunsHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "POST" {
-		// /test-runs is the legacy POST endpoint, migrated to /api/runs and left to avoid breakages.
+		// TODO(#251): Move consumers of old endpoint.
+		// /test-runs is the legacy POST endpoint, migrated to /api/runs, and left to avoid breakages
 		apiTestRunPostHandler(w, r)
 	} else if r.Method == "GET" {
 		handleTestRunGet(w, r)


### PR DESCRIPTION
Also improves some handler naming (too general for methods across the namespace) and fixes a bug with the populate_dev_data script (which is being deleted in https://github.com/w3c/wptdashboard/pull/248 anyway).