### PR TITLE
Add 'retroactive' param to allow adding a historical run

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -16,14 +16,15 @@ package wptdashboard
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
-	"fmt"
 )
 
 // apiTestRunsHandler is responsible for emitting test-run JSON for all the runs at a given SHA.
@@ -165,7 +166,12 @@ func apiTestRunPostHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to parse JSON: " + err.Error(), http.StatusBadRequest)
 		return
 	}
-	testRun.CreatedAt = time.Now()
+
+	// Use 'now' as created time, unless flagged as retroactive.
+	if retro, err := strconv.ParseBool(r.URL.Query().Get("retroactive"));
+	    err != nil || !retro {
+	    testRun.CreatedAt = time.Now()
+    }
 
 	// Create a new TestRun out of the JSON body of the request.
 	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)

--- a/api_handlers.go
+++ b/api_handlers.go
@@ -163,15 +163,14 @@ func apiTestRunPostHandler(w http.ResponseWriter, r *http.Request) {
 
 	var testRun TestRun
 	if err = json.Unmarshal(body, &testRun); err != nil {
-		http.Error(w, "Failed to parse JSON: " + err.Error(), http.StatusBadRequest)
+		http.Error(w, "Failed to parse JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	// Use 'now' as created time, unless flagged as retroactive.
-	if retro, err := strconv.ParseBool(r.URL.Query().Get("retroactive"));
-	    err != nil || !retro {
-	    testRun.CreatedAt = time.Now()
-    }
+	if retro, err := strconv.ParseBool(r.URL.Query().Get("retroactive")); err != nil || !retro {
+		testRun.CreatedAt = time.Now()
+	}
 
 	// Create a new TestRun out of the JSON body of the request.
 	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)

--- a/util/add_production_run.py
+++ b/util/add_production_run.py
@@ -71,7 +71,7 @@ def main():
                             % (test['browser_name'], test['revision']))
             continue
 
-        post_url = 'http://localhost:8080/api/run'
+        post_url = 'http://localhost:8080/api/run?' + urlencode({'retroactive': True})
         try:
             response = pool.request(
                 'POST',

--- a/util/add_production_run.py
+++ b/util/add_production_run.py
@@ -71,7 +71,8 @@ def main():
                             % (test['browser_name'], test['revision']))
             continue
 
-        post_url = 'http://localhost:8080/api/run?' + urlencode({'retroactive': True})
+        post_url = ('http://localhost:8080/api/run?'
+                    + urlencode({'retroactive': True}))
         try:
             response = pool.request(
                 'POST',


### PR DESCRIPTION
This is important for the add_production_run script to be able to copy old runs and not have them dated to the moment of copy.