### PR TITLE
Move apt-get installs to base and install virtualenv

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,14 +12,33 @@ ENV WPTD_OUT_PATH="${USER_HOME}/wptdout"
 
 RUN apt-get update
 
-# Install git, python-pip, and unzip for setup below
+# Install git, python-pip, virtualenv and unzip for setup below
 RUN apt-get install --assume-yes --no-install-suggests \
     --no-install-recommends \
     git \
     make \
     python-pip \
     python-setuptools \
+    virtualenv \
     unzip
+
+# Needed for hosts_fixup
+RUN apt-get install --assume-yes --no-install-suggests \
+    --no-install-recommends \
+    sudo
+
+# Used for running FF and Chrome
+RUN apt-get install --assume-yes --no-install-suggests \
+    --no-install-recommends \
+    xauth \
+    xvfb
+
+# Used for running FF
+RUN apt-get install --assume-yes --no-install-suggests \
+    --no-install-recommends \
+    libnss3-tools \
+    libgtk-3-common \
+    libdbus-glib-1-2
 
 # Install golang
 RUN mkdir /go-fetch

--- a/Dockerfile.jenkins
+++ b/Dockerfile.jenkins
@@ -1,23 +1,5 @@
 FROM wptd-base
 
-# Needed for hosts_fixup
-RUN apt-get install --assume-yes --no-install-suggests \
-    --no-install-recommends \
-    sudo
-
-# Used for running FF and Chrome
-RUN apt-get install --assume-yes --no-install-suggests \
-    --no-install-recommends \
-    xauth \
-    xvfb
-
-# Used for running FF
-RUN apt-get install --assume-yes --no-install-suggests \
-    --no-install-recommends \
-    libnss3-tools \
-    libgtk-3-common \
-    libdbus-glib-1-2
-
 ADD . "${WPTD_PATH}"
 
 # Expose Sauce Connect port


### PR DESCRIPTION
The apt-get virtualenv is to make sure it is in the PATH as an executable.

Moving these dependencies to base because when running a dev container we want to be able to run wpt run.

/cc @mdittmer 