### PR TITLE
Add IsBrowserName util method, and test it.

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -215,7 +215,8 @@ func getBrowserParam(r *http.Request) (browser string, err error) {
 	return "", nil
 }
 
-// getLastCompleteRunSHA returns the SHA[0:10] for the most recent run that complete for all of the given browser names.
+// getLastCompleteRunSHA returns the SHA[0:10] for the most recent run that exists for all initially-loaded browser
+// names (see GetBrowserNames).
 func getLastCompleteRunSHA(ctx context.Context) (sha string, err error) {
 	baseQuery := datastore.
 		NewQuery("TestRun").

--- a/api_handlers.go
+++ b/api_handlers.go
@@ -209,17 +209,8 @@ func getBrowserParam(r *http.Request) (browser string, err error) {
 		return browser, err
 	}
 
-	browserNames, err := GetBrowserNames()
-	if err != nil {
-		return browser, err
-	}
-
-	browser = params.Get("browser")
-	// Check that it's a browser name we recognize.
-	for _, name := range browserNames {
-		if name == browser {
-			return name, nil
-		}
+	if browser = params.Get("browser"); IsBrowserName(browser) {
+		return browser, nil
 	}
 	return "", nil
 }

--- a/util.go
+++ b/util.go
@@ -21,7 +21,10 @@ import (
 )
 
 var browsers map[string]Browser
-var browserNames []string
+
+// No 'set' type in Go, so use map instead.
+var browserNames map[string]bool
+var browserNamesAlphabetical []string
 
 // GetBrowsers loads, parses and returns the set of names of browsers
 // which are to be included (flagged as initially_loaded in the JSON).
@@ -44,20 +47,34 @@ func GetBrowsers() (map[string]Browser, error) {
 // GetBrowserNames returns an alphabetically-ordered array of the names
 // of the browsers returned by GetBrowsers.
 func GetBrowserNames() ([]string, error) {
-	if browserNames != nil {
-		return browserNames, nil
-	}
+	return browserNamesAlphabetical, nil
+}
 
+// IsBrowserName determines whether the given name string is a valid browser name.
+// Used for validating user-input params for browsers.
+func IsBrowserName(name string) bool {
+	if browserNames == nil {
+		if err := loadBrowserNames(); err != nil {
+			return false
+		}
+	}
+	_, ok := browserNames[name]
+	return ok
+}
+
+func loadBrowserNames() error {
 	var browsers map[string]Browser
 	var err error
 	if browsers, err = GetBrowsers(); err != nil {
-		return nil, err
+		return err
 	}
+	browserNames = make(map[string]bool)
 	for _, browser := range browsers {
 		if browser.InitiallyLoaded {
-			browserNames = append(browserNames, browser.BrowserName)
+			browserNamesAlphabetical = append(browserNamesAlphabetical, browser.BrowserName)
+			browserNames[browser.BrowserName] = true
 		}
 	}
-	sort.Strings(browserNames)
-	return browserNames, nil
+	sort.Strings(browserNamesAlphabetical)
+	return nil
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,41 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wptdashboard
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sort"
+	"testing"
+)
+
+func TestGetBrowserNames(t *testing.T) {
+	names, _ := GetBrowserNames()
+	assert.True(t, sort.StringsAreSorted(names))
+}
+
+func TestIsBrowserName(t *testing.T) {
+	assert.True(t, IsBrowserName("chrome"))
+	assert.True(t, IsBrowserName("edge"))
+	assert.True(t, IsBrowserName("firefox"))
+	assert.True(t, IsBrowserName("safari"))
+	assert.False(t, IsBrowserName("not-a-browser"))
+}
+
+func TestIsBrowserName_Names(t *testing.T) {
+	names, _ := GetBrowserNames()
+	for _, name := range names {
+		assert.True(t, IsBrowserName(name))
+	}
+}


### PR DESCRIPTION
This actually highlighted a bug where a function was re-using a global variable unintentionally (see getLastCompleteRunSHA).