### PR TITLE
Add --first-parent filter to first-SHA-of-day check

### DIFF
--- a/run/shas.py
+++ b/run/shas.py
@@ -46,6 +46,7 @@ class SHAFinder(object):
         command = [
             'git',
             'log',
+            '--first-parent',
             '--format=%H',
             '--after="%s T00:00:00Z"' % today.isoformat(),
             '--before="%s T00:00:00Z"' % tomorrow.isoformat(),


### PR DESCRIPTION
> Follow only the first parent commit upon seeing a merge commit. This option can give a better overview when viewing the evolution of a particular topic branch, because merges into a topic branch tend to be only about adjusting to updated upstream from time to time, and this option allows you to ignore the individual commits brought in to your history by such a merge.