### PR TITLE
Migrate /test-runs and / to use /api/runs

### DIFF
--- a/components/runs.html
+++ b/components/runs.html
@@ -51,7 +51,13 @@ limitations under the License.
                 return response.json()
               })
             )
-            this.testRuns = fetches.filter(e => e)  // Filter unresolved fetches.
+            // Filter unresolved fetches and flatten any array-fetches into the array.
+            const nonEmpty = fetches.filter(e => e)
+            const flattened = nonEmpty
+                .reduce((sum, item) => {
+                  return Array.isArray(item) ? sum.concat(item) : [...sum, item]
+                }, [])
+            this.testRuns = flattened
           }
         }
       }

--- a/components/wpt-runs.html
+++ b/components/wpt-runs.html
@@ -136,7 +136,7 @@ limitations under the License.
       }
 
       _computeDateTooltip(date) {
-        return date.toDateString()
+        return date && date.toDateString()
       }
 
       async connectedCallback () {

--- a/params.go
+++ b/params.go
@@ -96,12 +96,19 @@ func ParseBrowsersParam(r *http.Request) (browsers []string, err error) {
 	return browsers, nil
 }
 
-// ParseMaxCountParam parses the 'max-count' parameter as an integer.
+// ParseMaxCountParam parses the 'max-count' parameter as an integer, or returns 1 if no param
+// is present, or on error.
 func ParseMaxCountParam(r *http.Request) (count int, err error) {
-	count = MaxCountDefaultValue
+	return ParseMaxCountParamWithDefault(r, MaxCountDefaultValue)
+}
+
+// ParseMaxCountParamWithDefault parses the 'max-count' parameter as an integer, or returns the
+// default when no param is present, or on error.
+func ParseMaxCountParamWithDefault(r *http.Request, defaultValue int) (count int, err error) {
+	count = defaultValue
 	if maxCountParam := r.URL.Query().Get("max-count"); maxCountParam != "" {
 		if count, err = strconv.Atoi(maxCountParam); err != nil {
-			return MaxCountDefaultValue, err
+			return defaultValue, err
 		}
 		if count < MaxCountMinValue {
 			count = MaxCountMinValue

--- a/templates/test-runs.html
+++ b/templates/test-runs.html
@@ -10,7 +10,7 @@
 <div id="content">
   {{ template "_header.html" }}
   <div>
-    <wpt-runs test-runs="{{ .TestRuns }}"></wpt-runs>
+    <wpt-runs test-run-resources="{{ .TestRunSources }}"></wpt-runs>
   </div>
 </div>
 {{ template "_ga.html" }}

--- a/test_handler.go
+++ b/test_handler.go
@@ -34,18 +34,8 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var testRunSources []string
-	var browserNames []string
-	browserNames, err = GetBrowserNames()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	const sourceURL = `/api/run?browser=%s&sha=%s`
-	for _, browserName := range browserNames {
-		testRunSources = append(testRunSources, fmt.Sprintf(sourceURL, browserName, runSHA))
-	}
+	const sourceURL = `/api/runs?sha=%s`
+	testRunSources := []string{fmt.Sprintf(sourceURL, runSHA)}
 
 	testRunSourcesBytes, err := json.Marshal(testRunSources)
 	if err != nil {


### PR DESCRIPTION
For the index/homepage, this changes 4 /api/run fetch requests to a single /api/runs request.

For /test-runs, it defers the data-store fetch to the request from the client, greatly simplifying the Go code, with minimal effect to latency.

Running here:
https://20171127t105621-dot-wptdashboard.appspot.com

Note that this also allows for a bigger fetch of test-runs, which is related to https://github.com/w3c/wptdashboard/issues/73 - e.g.:
https://20171127t105621-dot-wptdashboard.appspot.com/test-runs?max-count=500