### PR TITLE
 Add POST method for /api/diff

### DIFF
--- a/api_handlers.go
+++ b/api_handlers.go
@@ -248,9 +248,23 @@ func getLastCompleteRunSHA(ctx context.Context) (sha string, err error) {
 	return "latest", nil
 }
 
-// apiDiffHandler takes 2 test-run results JSON files and produces
-// JSON in the same format, with only the differences in runs.
+// apiDiffHandler takes 2 test-run results JSON blobs and produces JSON in the same format, with only the differences
+// between runs.
+//
+// GET takes before and after params, for historical production runs.
+// POST takes only a before param, and the after state is provided in the body of the POST request.
 func apiDiffHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		handleAPIDiffGet(w, r)
+	case "POST":
+		handleAPIDiffPost(w, r)
+	default:
+		http.Error(w, fmt.Sprintf("invalid HTTP method %s", r.Method), http.StatusBadRequest)
+	}
+}
+
+func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 
 	var err error
@@ -285,6 +299,59 @@ func apiDiffHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	} else if afterJSON == nil {
 		http.Error(w, specAfter+" not found", http.StatusNotFound)
+		return
+	}
+
+	var filter DiffFilterParam
+	if filter, err = ParseDiffFilterParam(r); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	diffJSON := getResultsDiff(beforeJSON, afterJSON, filter)
+	var bytes []byte
+	if bytes, err = json.Marshal(diffJSON); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(bytes)
+}
+
+// handleAPIDiffPost handles POST requests to /api/diff, which allows the caller to produce the diff of an arbitrary
+// run result JSON blob against a historical production run.
+func handleAPIDiffPost(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+
+	var err error
+	params, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	specBefore := params.Get("before")
+	if specBefore == "" {
+		http.Error(w, "before param missing", http.StatusBadRequest)
+		return
+	}
+	var beforeJSON map[string][]int
+	if beforeJSON, err = fetchRunResultsJSONForParam(ctx, r, specBefore); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	} else if beforeJSON == nil {
+		http.Error(w, specBefore+" not found", http.StatusNotFound)
+		return
+	}
+
+	var body []byte
+	if body, err = ioutil.ReadAll(r.Body); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var afterJSON map[string][]int
+	if err = json.Unmarshal(body, &afterJSON); err != nil {
+		http.Error(w, "Failed to parse JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
Progresses https://github.com/w3c/wptdashboard/issues/301

POST allows an arbitrary JSON blob instead of the 'after' param as needed for the GET request.

This can be combined with https://github.com/w3c/wptdashboard/pull/303 to support a POST request after a test run which would be able to surface regressions.

