### PR TITLE
Package go code according to repo where it lives

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -61,6 +61,7 @@ RUN curl -L -o "go.tar.gz" "https://redirector.gvt1.com/edgedl/go/go${GO_VERSION
 # Setup go environment
 RUN mkdir "${USER_HOME}/go"
 ENV GOPATH="${USER_HOME}/go"
+ENV WPTD_GO_PATH="${GOPATH}/src/github.com/w3c/wptdashboard"
 
 # Setup go + python binaries path
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin:${USER_HOME}/.local/bin

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,7 +17,8 @@ RUN gcloud components install \
     kubectl
 
 # Put wptdashboard code in GOPATH
-RUN ln -s "${WPTD_PATH}" "${GOPATH}/src/wptdashboard"
+RUN mkdir -p "${GOPATH}/src/github.com/w3c"
+RUN ln -s "${WPTD_PATH}" "${GOPATH}/src/github.com/w3c/wptdashboard"
 
 # Drop dev environment into source path
 WORKDIR "${WPTD_PATH}"

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@
 SHELL := /bin/bash
 
 WPTD_PATH ?= /home/jenkins/wptdashboard
+WPTD_GO_PATH ?= $(GOPATH)/src/github.com/w3c/wptdashboard
 
 PB_LIB_DIR ?= ../protobuf/src
 PB_BQ_LIB_DIR ?= ../protoc-gen-bq-schema
@@ -55,12 +56,12 @@ py_test: py_proto py_deps
 	python -m unittest discover -p '*_test.py'
 
 go_lint: go_deps
-	golint -set_exit_status
+	cd $(WPTD_GO_PATH); golint -set_exit_status
 	# Print differences between current/gofmt'd output, check empty.
-	! gofmt -d . 2>&1 | read
+	cd $(WPTD_GO_PATH); ! gofmt -d . 2>&1 | read
 
 go_test: go_deps
-	go test -v ./...
+	cd $(WPTD_GO_PATH); go test -v ./...
 
 bq_proto: $(PROTOS)
 	mkdir -p $(PB_BQ_OUT_DIR)
@@ -81,4 +82,4 @@ py_deps: $(find . -type f | grep '\.py$' | grep -v '\_pb.py$')
 	pip install -r requirements.txt
 
 go_deps: $(find .  -type f | grep '\.go$' | grep -v '\.pb.go$')
-	cd $(GOPATH)/src/wptdashboard; go get -t ./...
+	cd $(WPTD_GO_PATH); go get -t ./...


### PR DESCRIPTION
This enables us to create sub-packages that depend on each other using `go get`'s idioms for package management.

E.g.,

```go
// repo-root/frobinator/frobinate.go
package frobinator;

import base "github.com/w3c/wptdashboard"

var runs []base.TestRun
```

```go
// repo-root/frobinator/run/main.go
package main;

import base "github.com/w3c/wptdashboard"
import "github.com/w3c/wptdashboard/frobinator"

func main() {
  var f frobinator.Frobinator
  var runs []base.TestRun
  // ...
}
```