### PR TITLE
Use 'go get' instead of git clone for bq-schema build

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -90,14 +90,15 @@ RUN curl -L -o "protoc.zip" "https://github.com/google/protobuf/releases/downloa
     rm -rf /protoc
 
 # Install protobuf BigQuery schema generator
-WORKDIR /
-RUN git clone "https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema.git" && \
-    cd "protoc-gen-bq-schema" && \
-    make && \
+ENV BQ_SCHEMA_PATH="github.com/GoogleCloudPlatform/protoc-gen-bq-schema"
+RUN go get ${BQ_SCHEMA_PATH}
+WORKDIR ${GOPATH}/src/${BQ_SCHEMA_PATH}
+# Copy executable to bin dir
+RUN make && \
     cp "bin/protoc-gen-bq-schema" /usr/local/bin/ && \
-    cd / && \
-    mv "/protoc-gen-bq-schema" "${USER_HOME}/protoc-gen-bq-schema" && \
     chmod a+rx "/usr/local/bin/protoc-gen-bq-schema"
+# Copy src to working/git dir
+RUN cp -r ${GOPATH}/src/${BQ_SCHEMA_PATH} ${USER_HOME}/protoc-gen-bq-schema
 
 RUN mkdir "${WPTD_PATH}"
 RUN mkdir "${WPT_PATH}"


### PR DESCRIPTION
This is needed to fix the fact that GoogleCloudPlatform/protoc-gen-bq-schema cannot build unless it's pulled into the Go path.

Note that I have concerns with the first commit for this PR, which while replicating the intended behaviour, leaves us in a state where we have a copy of protoc-gen-bq-schema both in $GOPATH/src/ and in the /home/jenkins (git root) dirs.

I think it best that this fix be followed with a tweak to the Makefile for wptdashboard to expect the executable to be built in the Go src dir, to prevent mismatches in future.