### PR TITLE
Add diff filter U for unchanged

### DIFF
--- a/webapp/params.go
+++ b/webapp/params.go
@@ -126,6 +126,10 @@ type DiffFilterParam struct {
 	// but the number of passes, failures, or total tests has changed.
 	Changed bool
 
+	// Unchanged tests are present in both the 'before' and 'after' states of the diff,
+	// and the number of passes, failures, or total tests is unchanged.
+	Unchanged bool
+
 	// Set of test paths to include, or include all tests if nil.
 	Paths mapset.Set
 }
@@ -149,6 +153,8 @@ func ParseDiffFilterParams(r *http.Request) (param DiffFilterParam, err error) {
 				param.Deleted = true
 			case 'C':
 				param.Changed = true
+			case 'U':
+				param.Unchanged = true
 			default:
 				return param, fmt.Errorf("invalid filter character %c", char)
 			}

--- a/webapp/params_test.go
+++ b/webapp/params_test.go
@@ -235,13 +235,17 @@ func TestParseDiffFilterParam(t *testing.T) {
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=CACA", nil)
 	filter, _ = ParseDiffFilterParams(r)
 	assert.Equal(t, DiffFilterParam{Added: true, Deleted: false, Changed: true}, filter)
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=U", nil)
+	filter, _ = ParseDiffFilterParams(r)
+	assert.Equal(t, DiffFilterParam{Unchanged: true}, filter)
 }
 
 func TestParseDiffFilterParam_Empty(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff", nil)
 	filter, err := ParseDiffFilterParams(r)
 	assert.Nil(t, err)
-	assert.Equal(t, true, filter.Changed && filter.Added && filter.Deleted)
+	assert.Equal(t, DiffFilterParam{Added: true, Deleted: true, Changed: true, Unchanged: false}, filter)
 }
 
 func TestParseDiffFilterParam_Invalid(t *testing.T) {

--- a/webapp/run_diff.go
+++ b/webapp/run_diff.go
@@ -134,12 +134,13 @@ func getResultsDiff(before map[string][]int, after map[string][]int, filter Diff
 				}
 				diff[test] = []int{resultsBefore[1], resultsBefore[1]}
 			} else {
-				if !filter.Changed {
+				if !filter.Changed && !filter.Unchanged {
 					continue
 				}
 				passDiff := abs(resultsBefore[0] - resultsAfter[0])
 				countDiff := abs(resultsBefore[1] - resultsAfter[1])
-				if countDiff == 0 && passDiff == 0 {
+				changed := passDiff != 0 || countDiff != 0
+				if (!changed && !filter.Unchanged) || changed && !filter.Changed {
 					continue
 				}
 				// Changed tests is at most the number of different outcomes,

--- a/webapp/test_handler.go
+++ b/webapp/test_handler.go
@@ -73,11 +73,12 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if specBefore != "" || specAfter != "" {
-		const diffRunURL = `/api/diff?before=%s&after=%s`
+		filter := "ACDU" // Added, Changed, Deleted, Unchanged
+		const diffRunURL = `/api/diff?before=%s&after=%s&filter=%s`
 		diffRun := models.TestRun{
 			Revision:    "diff",
 			BrowserName: "diff",
-			ResultsURL:  fmt.Sprintf(diffRunURL, specBefore, specAfter),
+			ResultsURL:  fmt.Sprintf(diffRunURL, specBefore, specAfter, filter),
 		}
 		var marshaled []byte
 		if marshaled, err = json.Marshal([]models.TestRun{diffRun}); err != nil {


### PR DESCRIPTION
While, for a diff, we generally want only things that have changed, this makes the totals/summary numbers look a bit strange on wpt.fyi. 

Including 'U' in the filter means that the total numbers of tests match, but the number of differences is unchanged.