### PR TITLE
components/test-file-results.html: use template strings

### DIFF
--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -128,7 +128,7 @@ found in the LICENSE file.
         const url = this.resultsURL(testRun, this.testFile)
         const response = await window.fetch(url)
         if (response.status !== 200) {
-          console.error('Got non-200 status for url:', url)
+          console.error(`Got non-200 status for url: ${url}`)
           return Promise.resolve(null)
         }
         return response.json()
@@ -136,10 +136,10 @@ found in the LICENSE file.
 
       resultsURL (testRun, testFile) {
         if (testRun.revision == 'diff') {
-          return testRun.results_url + '&path=' + encodeURI(testFile)
+          return `${testRun.results_url}&path=${encodeURI(testFile)}`
         }
         // This is relying on the assumption that result files are under a directory named SHA[0:10].
-        const resultsBase = testRun.results_url.split('/' + testRun.revision)[0]
+        const resultsBase = testRun.results_url.split(`/${testRun.revision}`)[0]
         // This is currently a hack to extract the platform ID from the summary URL.
         // A platform ID is any valid key from browsers.json.
         const platformID = testRun.results_url.split('/').pop().replace('-summary.json.gz', '')


### PR DESCRIPTION
Redoes the changes from https://github.com/w3c/wptdashboard/pull/319/commits/8c0d31fa6c7d0f33d06845cf77c3737dfeadb768, which got muddled via a bunch of merges.