### PR TITLE
Treat failed summary-fetch responses as empty JSON

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -266,7 +266,7 @@ found in the LICENSE file.
 
       async _fetchResults (url) {
         const response = await window.fetch(url);
-        const testFiles = await response.json();
+        const testFiles = response.ok ? await response.json() : {};
         return {testFiles: testFiles, resultsURL: url};
       }
 


### PR DESCRIPTION
This prevents a failure to parse (in the .json() call), which allows the other items to load in the UI correctly.