### PR TITLE
Don't cap the git depth at 50.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@
 
 sudo: required
 
+# Don't cap the git depth @50 (default), we check the nov 21 sha-of-the-day
+# in a py_test.
+git:
+  depth: false
+
 services:
   - docker
 


### PR DESCRIPTION
A better solution is to change that particular unit-test to execute a fetch, but this is the quick-fix to repair the build.