### PR TITLE
Abstract storage interface and push results to GCS + BQ

### DIFF
--- a/metrics/models.go
+++ b/metrics/models.go
@@ -176,15 +176,24 @@ type TestRunStatus struct {
 	Status CompleteTestStatus
 }
 
-type MetricsRun struct {
-	StartTime *time.Time    `json:"start_time"`
-	EndTime   *time.Time    `json:"end_time"`
-	TestRuns  *TestRunSlice `json:"test_runs"`
+type PassRateMetadata struct {
+	StartTime time.Time      `json:"start_time"`
+	EndTime   time.Time      `json:"end_time"`
+	TestRuns  []base.TestRun `json:"test_runs"`
+	DataUrl   string         `json:"url"`
+}
+
+type FailuresMetadata struct {
+	StartTime   time.Time      `json:"start_time"`
+	EndTime     time.Time      `json:"end_time"`
+	TestRuns    []base.TestRun `json:"test_runs"`
+	DataUrl     string         `json:"url"`
+	BrowserName string         `json:"browser_name"`
 }
 
 // Output type for metrics: Include runs as metadata, and arbitrary content
 // as data.
 type MetricsRunData struct {
-	MetricsRun *MetricsRun `json:"metrics_run"`
-	Data       interface{} `json:"data"`
+	Metadata interface{} `json:"metadata"`
+	Data     interface{} `json:"data"`
 }

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -176,6 +176,10 @@ type TestRunStatus struct {
 	Status CompleteTestStatus
 }
 
+// Metadata capturing:
+// - When metric run was performed;
+// - What test runs are part of the metric run;
+// - Where the metric run results reside (a URL).
 type PassRateMetadata struct {
 	StartTime time.Time      `json:"start_time"`
 	EndTime   time.Time      `json:"end_time"`
@@ -183,6 +187,11 @@ type PassRateMetadata struct {
 	DataUrl   string         `json:"url"`
 }
 
+// Metadata capturing:
+// - When failures report was gathered;
+// - What test runs are part of the failures report;
+// - Where the failures report resids (a URL);
+// - What browser is described in the report.
 type FailuresMetadata struct {
 	StartTime   time.Time      `json:"start_time"`
 	EndTime     time.Time      `json:"end_time"`

--- a/metrics/run/collect_metrics.go
+++ b/metrics/run/collect_metrics.go
@@ -204,7 +204,7 @@ func main() {
 			log.Printf("Upload error: %v", err)
 		}
 		if len(errs) > 0 {
-			log.Fatal(err)
+			log.Fatal(errs[len(errs)-1])
 		}
 	}
 	for _, outputter := range outputters {

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -8,12 +8,17 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
 
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/datastore"
 	"cloud.google.com/go/storage"
 	tm "github.com/buger/goterm"
 	"github.com/w3c/wptdashboard/metrics"
@@ -22,45 +27,235 @@ import (
 	"google.golang.org/api/iterator"
 )
 
+type OutputLocation struct {
+	GCSObjectPath string
+	BQDatasetName string
+	BQTableName   string
+}
+
+type OutputId struct {
+	MetadataLocation OutputLocation
+	DataLocation     OutputLocation
+}
+
+type Outputter interface {
+	Output(OutputId, interface{}, []interface{}) (interface{}, []interface{}, []error)
+}
+
 // Encapsulate bucket name and handle; both are needed for some storage
 // read/write routines.
 type Bucket struct {
-	Name   *string
+	Name   string
 	Handle *storage.BucketHandle
 }
 
 // Encapsulate info required to read from or write to a storage bucket.
-type Context struct {
+type GCSDatastoreContext struct {
 	Context context.Context
-	Client  *storage.Client
-	Bucket  *Bucket
+	Bucket  Bucket
+	Client  *datastore.Client
 }
 
-// Upload metricsRunData as objName in bucket via client in context.
-func UploadMetricsRunData(ctx *Context, objName *string,
-	metricsRunData *metrics.MetricsRunData) (err error) {
+type GCSData struct {
+	Metadata interface{}   `json:"metadata"`
+	Data     []interface{} `json:"data"`
+}
 
-	log.Println("Writing " + *objName + " to Google Cloud Storage")
-	obj := ctx.Bucket.Handle.Object(*objName)
+type BQDataset struct {
+	Name    string
+	Dataset *bigquery.Dataset
+}
+
+type BQTable struct {
+	Name  string
+	Table *bigquery.Table
+}
+
+type BQCollection struct {
+	Dataset BQDataset
+	Table   BQTable
+}
+
+type BQContext struct {
+	Context context.Context
+	Client  *bigquery.Client
+}
+
+func (ctx GCSDatastoreContext) Output(id OutputId, metadata interface{},
+	data []interface{}) (
+	metadataWritten interface{}, dataWritten []interface{}, errs []error) {
+	name := fmt.Sprintf("%s/%s", ctx.Bucket.Name,
+		id.DataLocation.GCSObjectPath)
+	log.Printf("Writing %s to Google Cloud Storage\n", name)
+	gcsData := GCSData{metadata, data}
+	obj := ctx.Bucket.Handle.Object(id.DataLocation.GCSObjectPath)
+	_, err := obj.Update(ctx.Context, storage.ObjectAttrsToUpdate{
+		ContentEncoding: "gzip",
+	})
+	if err != nil {
+		log.Printf("Error setting new Google Cloud Storage object Content-Encoding to \"gzip\": %v",
+			err)
+		errs = append(errs, err)
+		return nil, make([]interface{}, 0), errs
+	}
 	objWriter := obj.NewWriter(ctx.Context)
 	defer objWriter.Close()
 	gzWriter := gzip.NewWriter(objWriter)
 	defer gzWriter.Close()
 	encoder := json.NewEncoder(gzWriter)
-	err = encoder.Encode(metricsRunData)
-	if err != nil {
+	if err := encoder.Encode(gcsData); err != nil {
 		log.Printf("Error writing %s to Google Cloud Storage: %v\n",
-			*objName, err)
-		return err
+			name, err)
+		errs = append(errs, err)
+		return nil, make([]interface{}, 0), errs
 	}
-	log.Println("Wrote " + *objName + " to Google Cloud Storage")
+	log.Printf("Wrote %s to Google Cloud Storage\n", name)
 
-	return err
+	dataWritten = data
+
+	log.Printf("Writing %s to Datastore\n", name)
+	metadataType := reflect.TypeOf(metadata)
+	for metadataType.Kind() == reflect.Ptr {
+		metadataType = reflect.Indirect(reflect.ValueOf(
+			metadata)).Type()
+	}
+	metadataKindName := fmt.Sprintf("%s.%s",
+		strings.Replace(metadataType.PkgPath(), "/", ".", -1),
+		metadataType.Name())
+	metadataKey := datastore.IncompleteKey(metadataKindName, nil)
+
+	// TODO: This is terrible, but Datastore doesn't use reflection, so the
+	// metadata must be of a concrete struct type.
+	err = nil
+	passRateMetadata, ok := metadata.(*metrics.PassRateMetadata)
+	if !ok {
+		failuresMetadata, ok := metadata.(*metrics.FailuresMetadata)
+		if !ok {
+			return nil, make([]interface{}, 0), []error{
+				errors.New("Unknown metadata type"),
+			}
+		}
+		_, err = ctx.Client.Put(ctx.Context, metadataKey,
+			failuresMetadata)
+	} else {
+		_, err = ctx.Client.Put(ctx.Context, metadataKey,
+			passRateMetadata)
+	}
+	if err != nil {
+		log.Printf("Error writing %s to Datastore: %v\n",
+			name, err)
+		errs = append(errs, err)
+		return nil, dataWritten, errs
+	}
+	log.Printf("Wrote %s to Google Cloud Storage\n", name)
+
+	metadataWritten = metadata
+
+	return metadataWritten, dataWritten, errs
+}
+
+func (ctx BQContext) Output(id OutputId, metadata interface{},
+	data []interface{}) (metadataWritten interface{},
+	dataWritten []interface{}, errs []error) {
+	dataName := fmt.Sprintf("%s.%s", id.DataLocation.BQDatasetName,
+		id.DataLocation.BQTableName)
+	metadataName := fmt.Sprintf("%s.%s",
+		id.MetadataLocation.BQDatasetName,
+		id.MetadataLocation.BQTableName)
+	log.Printf("Writing data to %s, %s BigQuery tables\n", dataName,
+		metadataName)
+
+	dataDataset := ctx.Client.Dataset(id.DataLocation.BQDatasetName)
+	dataTable := dataDataset.Table(id.DataLocation.BQTableName)
+	metadataDataset := ctx.Client.Dataset(id.MetadataLocation.BQDatasetName)
+	metadataTable := dataDataset.Table(id.MetadataLocation.BQTableName)
+
+	if err := dataDataset.Create(ctx.Context, nil); err != nil {
+		log.Printf("Error creating BigQuery dataset %s for data (continuing anyway): %v\n",
+			id.DataLocation.BQDatasetName, err)
+	}
+	if err := metadataDataset.Create(ctx.Context, nil); err != nil {
+		log.Printf("Error creating BigQuery dataset %s for metadata (continuing anyway): %v\n",
+			id.MetadataLocation.BQDatasetName, err)
+	}
+
+	metadataSchema, err := bigquery.InferSchema(metadata)
+	if err != nil {
+		log.Printf("Error creating BigQuery schema for metadata: %v\n",
+			err)
+		errs = append(errs, err)
+		return metadataWritten, dataWritten, errs
+	}
+	dataSchema, err := bigquery.InferSchema(data[0])
+	if err != nil {
+		log.Printf("Error creating BigQuery schema for data: %v\n",
+			err)
+		errs = append(errs, err)
+		return metadataWritten, dataWritten, errs
+	}
+
+	if err := dataTable.Create(ctx.Context, &bigquery.TableMetadata{
+		Schema: dataSchema,
+	}); err != nil {
+		log.Printf("Error creating BigQuery table %s for data (continuing anyway): %v\n",
+			dataName, err)
+	}
+	if err := metadataTable.Create(ctx.Context, &bigquery.TableMetadata{
+		Schema: metadataSchema,
+	}); err != nil {
+		log.Printf("Error creating BigQuery table %s for metadata (continuing anyway): %v\n",
+			metadataName, err)
+	}
+
+	dataUploader := dataTable.Uploader()
+	metadataUploader := metadataTable.Uploader()
+
+	step := 10000
+	limit := len(data)
+	for startIdx, endIdx := 0, step; startIdx < limit; startIdx, endIdx = startIdx+step, endIdx+step {
+		if endIdx > limit {
+			endIdx = limit
+		}
+		dataSlice := data[startIdx:endIdx]
+		for err = dataUploader.Put(ctx.Context, dataSlice); err != nil; err = dataUploader.Put(ctx.Context, dataSlice) {
+			log.Printf("Failed to write %d records to BigQuery table %s: %v\n",
+				len(dataSlice), dataName, err)
+			multiErr, ok := err.(bigquery.PutMultiError)
+			if !ok {
+				errs := append(errs, err)
+				return metadataWritten, dataWritten, errs
+			}
+			log.Printf("Retrying data write to BigQuery table %s\n",
+				dataName)
+			newSlice := make([]interface{}, 0, len(multiErr))
+			for _, rowInsertionErr := range multiErr {
+				newSlice = append(newSlice,
+					dataSlice[rowInsertionErr.RowIndex])
+			}
+			dataSlice = newSlice
+		}
+	}
+
+	dataWritten = data
+
+	if err := metadataUploader.Put(ctx.Context, metadata); err != nil {
+		log.Printf("Error writing metadata to BigQuery table %s: %v\n",
+			metadataName, err)
+		errs = append(errs, err)
+		return metadataWritten, dataWritten, errs
+	}
+
+	metadataWritten = metadata
+
+	log.Printf("Wrote data to %s, %s BigQuery tables\n", dataName,
+		metadataName)
+
+	return metadataWritten, dataWritten, errs
 }
 
 // Load (test run, test results) pairs for given test runs. Use client in
 // context to load data from bucket.
-func LoadTestRunResults(ctx *Context, runs []base.TestRun) (
+func LoadTestRunResults(ctx *GCSDatastoreContext, runs []base.TestRun) (
 	runResults []metrics.TestRunResults) {
 	resultChan := make(chan metrics.TestRunResults, 0)
 	errChan := make(chan error, 0)
@@ -127,7 +322,7 @@ func LoadTestRunResults(ctx *Context, runs []base.TestRun) (
 	return runResults
 }
 
-func processTestRun(ctx *Context, testRun *base.TestRun,
+func processTestRun(ctx *GCSDatastoreContext, testRun *base.TestRun,
 	resultChan chan metrics.TestRunResults, errChan chan error) {
 	resultsURL := testRun.ResultsURL
 
@@ -142,8 +337,8 @@ func processTestRun(ctx *Context, testRun *base.TestRun,
 	// Desired bucket-relative GCS prefix:
 	//
 	// dir/path/
-	prefixSliceStart := strings.Index(resultsURL, *ctx.Bucket.Name) +
-		len(*ctx.Bucket.Name) + 1
+	prefixSliceStart := strings.Index(resultsURL, ctx.Bucket.Name) +
+		len(ctx.Bucket.Name) + 1
 	prefixSliceEnd := strings.LastIndex(resultsURL, "-")
 	prefix := resultsURL[prefixSliceStart:prefixSliceEnd] + "/"
 
@@ -182,8 +377,9 @@ func processTestRun(ctx *Context, testRun *base.TestRun,
 	wg.Wait()
 }
 
-func loadTestResults(ctx *Context, testRun *base.TestRun, objName string,
-	resultChan chan metrics.TestRunResults, errChan chan error) {
+func loadTestResults(ctx *GCSDatastoreContext, testRun *base.TestRun,
+	objName string, resultChan chan metrics.TestRunResults,
+	errChan chan error) {
 	// Read object from GCS
 	obj := ctx.Bucket.Handle.Object(objName)
 	reader, err := obj.NewReader(ctx.Context)


### PR DESCRIPTION
The interface is now cleaner and allows for multiple implementations. This is illustrated by providing and leveraging a BigQuery implementation (in addition to the existing Datastore-metadata + CloudStorage-data implementation).