### PR TITLE
Rename sorting handlers

### DIFF
--- a/metrics/models.go
+++ b/metrics/models.go
@@ -10,45 +10,26 @@ import (
 	base "github.com/w3c/wptdashboard/shared"
 )
 
-//
-// Sortable slices of test runs
-//
-type TestRunSlice []base.TestRun
+// ByCreatedDate sorts tests by run's CreatedAt date (descending)
+// then by platform alphabetically (ascending).
+type ByCreatedDate []base.TestRun
 
-func (s TestRunSlice) Len() int {
-	return len(s)
-}
-
-func (s TestRunSlice) Less(i int, j int) bool {
-	if s[i].Revision < s[j].Revision {
-		return true
+func (s ByCreatedDate) Len() int          { return len(s) }
+func (s ByCreatedDate) Swap(i int, j int) { s[i], s[j] = s[j], s[i] }
+func (s ByCreatedDate) Less(i int, j int) bool {
+	if s[i].Revision != s[j].Revision {
+		return s[i].CreatedAt.After(s[j].CreatedAt)
 	}
-	if s[i].Revision > s[j].Revision {
-		return false
+	if s[i].BrowserName != s[j].BrowserName {
+		return s[i].BrowserName < s[j].BrowserName
 	}
-	if s[i].BrowserName < s[j].BrowserName {
-		return true
+	if s[i].BrowserVersion != s[j].BrowserVersion {
+		return s[i].BrowserVersion < s[j].BrowserVersion
 	}
-	if s[i].BrowserName > s[j].BrowserName {
-		return false
-	}
-	if s[i].BrowserVersion < s[j].BrowserVersion {
-		return true
-	}
-	if s[i].BrowserVersion > s[j].BrowserVersion {
-		return false
-	}
-	if s[i].OSName < s[j].OSName {
-		return true
-	}
-	if s[i].OSName > s[j].OSName {
-		return false
+	if s[i].OSName != s[j].OSName {
+		return s[i].OSName < s[j].OSName
 	}
 	return s[i].OSVersion < s[j].OSVersion
-}
-
-func (s TestRunSlice) Swap(i int, j int) {
-	s[i], s[j] = s[j], s[i]
 }
 
 type SubTest struct {
@@ -74,24 +55,16 @@ type TestId struct {
 	Name string `json:"name"`
 }
 
-type TestIdSlice []TestId
+// ByTestPath sorts test ids by their test path, then name, descending.
+type ByTestPath []TestId
 
-func (s TestIdSlice) Len() int {
-	return len(s)
-}
-
-func (s TestIdSlice) Less(i int, j int) bool {
-	if s[i].Test < s[j].Test {
-		return true
-	}
-	if s[i].Test > s[j].Test {
-		return false
+func (s ByTestPath) Len() int          { return len(s) }
+func (s ByTestPath) Swap(i int, j int) { s[i], s[j] = s[j], s[i] }
+func (s ByTestPath) Less(i int, j int) bool {
+	if s[i].Test != s[j].Test {
+		return s[i].Test < s[j].Test
 	}
 	return s[i].Name < s[j].Name
-}
-
-func (s TestIdSlice) Swap(i int, j int) {
-	s[i], s[j] = s[j], s[i]
 }
 
 // Enum: Test status, according to legitimate string values in WPT results

--- a/metrics/models_test.go
+++ b/metrics/models_test.go
@@ -1,0 +1,86 @@
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package metrics
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	models "github.com/w3c/wptdashboard/shared"
+)
+
+var today = time.Date(2018, 1, 4, 0, 0, 0, 0, time.UTC)
+var tomorrow = time.Date(2018, 1, 5, 0, 0, 0, 0, time.UTC)
+
+func TestByCreatedDate_DifferentRevisions(t *testing.T) {
+	tests := []models.TestRun{
+		{
+			Revision:    "abc",
+			CreatedAt:   today,
+			BrowserName: "chrome",
+		},
+		{
+			Revision:    "def",
+			CreatedAt:   tomorrow,
+			BrowserName: "safari",
+		},
+	}
+	sort.Sort(ByCreatedDate(tests))
+	fmt.Print(tests)
+	assert.True(t, tests[0].CreatedAt == tomorrow)
+}
+
+func TestByCreatedDate_SameRevisions(t *testing.T) {
+	tests := []models.TestRun{
+		{
+			Revision:    "abc",
+			CreatedAt:   today,
+			BrowserName: "chrome",
+		},
+		{
+			Revision:    "abc",
+			CreatedAt:   tomorrow,
+			BrowserName: "safari",
+		},
+	}
+	sort.Sort(ByCreatedDate(tests))
+	fmt.Print(tests)
+	assert.True(t, tests[0].BrowserName == "chrome")
+}
+
+func TestByTestPath_DifferentPaths(t *testing.T) {
+	tests := []TestId{
+		{
+			Test: "/bcd/efg",
+			Name: "Alignment test",
+		},
+		{
+			Test: "/abc/def",
+			Name: "Border test",
+		},
+	}
+	sort.Sort(ByTestPath(tests))
+	fmt.Print(tests)
+	assert.True(t, tests[0].Test == "/abc/def")
+}
+
+func TestByTestPath_SamePaths(t *testing.T) {
+	tests := []TestId{
+		{
+			Test: "/abc/def",
+			Name: "Border test",
+		},
+		{
+			Test: "/abc/def",
+			Name: "Alignment test",
+		},
+	}
+	sort.Sort(ByTestPath(tests))
+	fmt.Print(tests)
+	assert.True(t, tests[0].Name == "Alignment test")
+}

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -293,11 +293,11 @@ func LoadTestRunResults(ctx *GCSDatastoreContext, runs []base.TestRun) (
 			}
 			progress[testRun] = progress[testRun] + 1
 
-			keys := make(metrics.TestRunSlice, 0, len(progress))
+			keys := make([]base.TestRun, 0, len(progress))
 			for key := range progress {
 				keys = append(keys, key)
 			}
-			sort.Sort(keys)
+			sort.Sort(metrics.ByCreatedDate(keys))
 
 			tm.Clear()
 			tm.MoveCursor(1, 1)


### PR DESCRIPTION
There are a couple different golang examples, and I much prefer this one (more explicit, simpler to re-use).