### PR TITLE
Give names to (and add) interop views

### DIFF
--- a/webapp/anomaly_handler.go
+++ b/webapp/anomaly_handler.go
@@ -1,0 +1,20 @@
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package webapp
+
+import (
+	"net/http"
+)
+
+// anomalyHandler handles the view of test results showing which tests pass in
+// some, but not all, browsers.
+func anomalyHandler(w http.ResponseWriter, r *http.Request) {
+	// Empty struct placeholder.
+	data := struct{}{}
+	if err := templates.ExecuteTemplate(w, "anomalies.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -1,0 +1,20 @@
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package webapp
+
+import (
+	"net/http"
+)
+
+// interopHandler handles the view of test results broken down by the
+// number of browsers for which the test passes.
+func interopHandler(w http.ResponseWriter, r *http.Request) {
+	// Empty struct placeholder.
+	data := struct{}{}
+	if err := templates.ExecuteTemplate(w, "interoperability.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/webapp/main.go
+++ b/webapp/main.go
@@ -19,6 +19,12 @@ func init() {
 	// About wpt.fyi
 	http.HandleFunc("/about", aboutHandler)
 
+	// Test run results, viewed by pass-rate across the browsers
+	http.HandleFunc("/interop/", interopHandler)
+
+	// Lists of test run results which have poor interoperability
+	http.HandleFunc("/interop/anomalies", anomalyHandler)
+
 	// List of all test runs, by SHA[0:10]
 	http.HandleFunc("/test-runs", testRunsHandler)
 

--- a/webapp/templates/anomalies.html
+++ b/webapp/templates/anomalies.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+{{ template "_head.html" }}
+<body>
+
+<div id="content">
+{{ template "_header.html" }}
+    <div>
+        Interoperability anomalies view coming soon.
+    </div>
+</div>
+{{ template "_ga.html" }}
+</body>
+</html>

--- a/webapp/templates/interoperability.html
+++ b/webapp/templates/interoperability.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+{{ template "_head.html" }}
+<body>
+
+<div id="content">
+{{ template "_header.html" }}
+    <div>
+        Interoperability view coming soon.
+    </div>
+</div>
+{{ template "_ga.html" }}
+</body>
+</html>


### PR DESCRIPTION
mdittmers [metrics demo](https://metrics5-dot-wptdashboard.appspot.com/metrics/) is one of two views from the [metrics design](https://docs.google.com/document/d/1MZRF3EdpMG0pLNI99jEj-pBITbqWKYMyJC7Ga8NtZ88/edit), which intends to add a view to show tests broken down by the number of browsers they pass in.

There are two views:
  - a list of tests that pass in some, but not all, browsers
  - the view demo'd above, i.e. tests broken down by interoperability

This PR adds placeholder endpoints for these views, and the main objective of the PR is to pick a name for each view.