### PR TITLE
run/run.py: support providing an explicit wpt commit sha

### DIFF
--- a/run/run_test.py
+++ b/run/run_test.py
@@ -2,12 +2,36 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import logging
+import mock
+import os
+import shas
+import subprocess
 import unittest
 
 from run import (
     report_to_summary,
-    version_string_to_major_minor
+    version_string_to_major_minor,
+    setup_wpt
 )
+
+import run
+
+
+def stub_patch_wpt(a, b):
+    return 0
+
+
+def stub_check_call(a, cwd):
+    return 0
+
+
+class Args:
+    def __init__(self):
+        self.wpt_sha = ''
+
+
+logger = mock.Mock(logging.Logger)
 
 
 class TestRun(unittest.TestCase):
@@ -41,6 +65,39 @@ class TestRun(unittest.TestCase):
             version_string_to_major_minor('')
         self.assertEqual(version_string_to_major_minor('1.1'), '1.1')
         self.assertEqual(version_string_to_major_minor('1.1.1'), '1.1')
+
+    def test_setup_wpt_explicit_sha(self):
+        run.patch_wpt = stub_patch_wpt
+        subprocess.check_call = stub_check_call
+
+        args = Args()
+        args.wpt_sha = '1234567890'
+        config = {'wpt_path': os.path.dirname(os.path.realpath(__file__))}
+
+        self.assertEqual(setup_wpt(args, {}, config, logger), args.wpt_sha)
+
+    def test_setup_wpt_find_sha(self):
+        run.patch_wpt = stub_patch_wpt
+        subprocess.check_call = stub_check_call
+        shas.SHAFinder = mock.Mock(shas.SHAFinder)
+
+        args = Args()
+        args.wpt_sha = None
+        config = {'wpt_path': os.path.dirname(os.path.realpath(__file__))}
+
+        self.assertNotEqual(setup_wpt(args, {}, config, logger), args.wpt_sha)
+        self.assertEqual(shas.SHAFinder.called, True)
+
+    def test_setup_wpt_calls_patch_wpt(self):
+        run.patch_wpt = mock.Mock(run.patch_wpt)
+        subprocess.check_call = stub_check_call
+
+        args = Args()
+        args.wpt_sha = '1234567890'
+        config = {'wpt_path': os.path.dirname(os.path.realpath(__file__))}
+
+        setup_wpt(args, {}, config, logger)
+        self.assertEqual(run.patch_wpt.called, True)
 
 
 if __name__ == '__main__':

--- a/run/shas.py
+++ b/run/shas.py
@@ -58,7 +58,7 @@ class SHAFinder(object):
         command = [
             'git',
             'rev-parse',
-            'HEAD',
+            'origin/HEAD',
         ]
         abspath = os.path.abspath(path)
         self.logger.debug('Using dir ' + abspath)


### PR DESCRIPTION
Supporting work for: 

> KR: wpt.fyi always shows results for the same wpt commit (P2)

This allows a remote test runner machine to specify which commit SHA of wpt should be run. Next, we need to decide on how to establish the "source of truth", ie. _what_ determines that SHA and then _where_ that information lives. 


To run the tests directly: 

```
docker exec -it -u $(id -u $USER):$(id -g $USER) wptd-dev-instance python run/run_test.py
```