### PR TITLE
Set an explicit App ID for local instance

### DIFF
--- a/util/docker-dev/web_server.sh
+++ b/util/docker-dev/web_server.sh
@@ -25,4 +25,5 @@ docker exec -it -u $(id -u $USER):$(id -g $USER) wptd-dev-instance \
     --admin_port=8000 \
     --api_host=$WPTD_CONTAINER_HOST \
     --api_port=9999 \
+    -A=wptdashboard \
     webapp


### PR DESCRIPTION
This is needed to avoid a bug in AppEngine's Datastore API, where 2 different code paths (Key creation and Entity Put) use a different default/empty App ID ("" and "None" respectively).

We use the remote_api code from populate_dev_data.go in https://github.com/w3c/wptdashboard/pull/347