### PR TITLE
List all anomaly tests on the anomalies page.

### DIFF
--- a/webapp/anomaly_handler.go
+++ b/webapp/anomaly_handler.go
@@ -5,14 +5,94 @@
 package webapp
 
 import (
+	"encoding/json"
+	"github.com/w3c/wptdashboard/metrics"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/datastore"
 	"net/http"
 )
+
+type AnomalyData struct {
+	Metadata string
+	Browser  string
+}
 
 // anomalyHandler handles the view of test results showing which tests pass in
 // some, but not all, browsers.
 func anomalyHandler(w http.ResponseWriter, r *http.Request) {
-	// Empty struct placeholder.
-	data := struct{}{}
+	browser, err := ParseBrowserParam(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	} else if browser != "" {
+		browserAnomalyHandler(w, r, browser)
+		return
+	}
+
+	ctx := appengine.NewContext(r)
+	query := datastore.
+		NewQuery(metrics.GetDatastoreKindName(
+			metrics.PassRateMetadata{})).
+		Order("-StartTime").Limit(1)
+	var metadataSlice []metrics.PassRateMetadata
+
+	if _, err := query.GetAll(ctx, &metadataSlice); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(metadataSlice) != 1 {
+		http.Error(w, "No metrics runs found",
+			http.StatusInternalServerError)
+		return
+	}
+
+	metadataBytes, err := json.Marshal(metadataSlice[0])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	data := AnomalyData{
+		Metadata: string(metadataBytes),
+	}
+
+	if err := templates.ExecuteTemplate(w, "anomalies.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+// browserAnomalyHandler handles the view of test results showing which tests
+// fail in a specific browser, but pass in at least one other browser.
+func browserAnomalyHandler(w http.ResponseWriter, r *http.Request, browser string) {
+	ctx := appengine.NewContext(r)
+	query := datastore.
+		NewQuery(metrics.GetDatastoreKindName(
+			metrics.FailuresMetadata{})).
+		Order("-StartTime").
+		Filter("BrowserName =", browser).
+		Limit(1)
+	var metadataSlice []metrics.FailuresMetadata
+
+	if _, err := query.GetAll(ctx, &metadataSlice); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(metadataSlice) != 1 {
+		http.Error(w, "No metrics runs found",
+			http.StatusInternalServerError)
+		return
+	}
+
+	metadataBytes, err := json.Marshal(metadataSlice[0])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	data := AnomalyData{
+		Metadata: string(metadataBytes),
+		Browser:  browser,
+	}
+
 	if err := templates.ExecuteTemplate(w, "anomalies.html", data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/webapp/components/anomalies.html
+++ b/webapp/components/anomalies.html
@@ -1,0 +1,131 @@
+<!--
+Copyright 2017 The WPT Dashboard Project. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="runs.html">
+<link rel="import" href="test-file-results.html">
+<link rel="import" href="test-run.html">
+
+<dom-module id="wpt-anomalies">
+  <template>
+    <style>
+    </style>
+
+    <section class="caveat">
+      Data below are intended for web platform implementers and do not contain useful metrics for evaluation or comparison of web platform features. Also note that tested Edge and Safari are not pre-release versions (<a href="https://github.com/w3c/wptdashboard/issues/109">#109</a>, <a href="https://github.com/w3c/wptdashboard/issues/110">#110</a>).
+    </section>
+
+    <template is="dom-repeat" items="{{anomalyGroups}}" as="anomalyGroup" itemsIndexAs="index">
+      <template is="dom-if" if="{{browser}}">
+        <h2>Failing in [[browser]] and [[index]] other browsers</h2>
+      </template>
+      <template is="dom-if" if="{{!browser}}">
+        <h2>Passing in [[anomalyGroup.passingBrowsers]] browsers</h2>
+      </template>
+      <template is="dom-repeat" items="{{anomalyGroup.tests}}" as="test">
+        <a href="[[test]]">[[test]]</a><br />
+      </template>
+    </template>
+  </template>
+
+  <script>
+    /**
+     * Component for viewing a list of anomalies in a group of TestRuns across
+     * multiple browsers, where anomalies are tests which are not interoperable
+     * (i.e. pass in some, but not all, browsers).
+     */
+    class WPTAnomalies extends window.Polymer.Element {
+      static get is() { return 'wpt-anomalies'; }
+
+      static get properties() {
+        return {
+          /**
+           * Metadata including the source url, runs, and times for the metrics
+           * computed for a set of test runs.
+           */
+          passRateMetadata: {
+            type: Object,
+          },
+          /**
+           * The processed contents of the metrics from the source url, once it
+           * has been fetched.
+           * Contains a map of [Pass rate] -> [Passing tests]
+           * where [Pass rate] is the number of browsers that a test passes in.
+           */
+          anomalyGroups: {
+            type: Object,
+          },
+          /**
+           * Browser for which to view browser-specific anomalies (optional).
+           */
+          browser: {
+            type: String,
+            value: ''
+          }
+        };
+      }
+
+      async connectedCallback() {
+        await super.connectedCallback();
+
+        // Fetch the results JSON for the TestRuns
+        const metrics = await this.fetchResults(this.passRateMetadata.url);
+
+        let anomalies = metrics.data;
+        if (!this.browser) {
+          anomalies = anomalies.filter(d => isTestFile(d.dir));
+        }
+        
+        const totalBrowsers = metrics.metadata.test_runs.length;
+
+        // For each pass-rate (browser count), build a tree of tests + directories.
+        let anomalyGroups = [];
+        // We only want anomalies; at least one pass, at most N-1 passes.
+        for (let passes = 1; passes < totalBrowsers; passes++) {
+          anomalyGroups.push({ passingBrowsers: passes, tests: [] });
+        }
+        for (let data of anomalies) {
+          // Filter dir-level items when not in browser-specific view.
+          if (!this.browser && !isTestFile(data.dir)) {
+            continue;
+          }
+          let testPath = !this.browser
+            ? data.dir
+            : data.test.test;
+          if (this.browser) {
+            if (data.num_other_failures + 1 >= totalBrowsers) {
+              continue
+            }
+            anomalyGroups[data.num_other_failures].tests.push(testPath);
+          } else {
+            // Sub-tests are aggregated when not in browser-specific view; handle each.
+            for (let i in data.pass_rates) {
+              const pass_rate = data.pass_rates[i];
+              if (i < 1 || i >= totalBrowsers || pass_rate < 1) {
+                continue
+              }
+              anomalyGroups[i - 1].tests.push(testPath);
+            }
+          }
+        }
+        this.anomalyGroups = anomalyGroups
+      }
+
+      async fetchResults (url) {
+        const response = await window.fetch(url);
+        return response.ok ? await response.json() : {};
+      }
+    }
+
+    function isTestFile(path) {
+      return /(\.(html|htm|py|svg|xhtml|xht|xml)$)/.test(path);
+    }
+
+    window.customElements.define(WPTAnomalies.is, WPTAnomalies);
+  </script>
+</dom-module>

--- a/webapp/components/anomalies.html
+++ b/webapp/components/anomalies.html
@@ -22,13 +22,13 @@ found in the LICENSE file.
 
     <template is="dom-repeat" items="{{anomalyGroups}}" as="anomalyGroup" itemsIndexAs="index">
       <template is="dom-if" if="{{browser}}">
-        <h2>Failing in [[browser]] and [[index]] other browsers</h2>
+        <h2>Failing in [[browser]] and [[computeOtherBrowserCount(index)]]</h2>
       </template>
       <template is="dom-if" if="{{!browser}}">
-        <h2>Passing in [[anomalyGroup.passingBrowsers]] browsers</h2>
+        <h2>Passing in [[computeBrowserCount(anomalyGroup.passingBrowsers)]]</h2>
       </template>
       <template is="dom-repeat" items="{{anomalyGroup.tests}}" as="test">
-        <a href="[[test]]">[[test]]</a><br />
+        <a href="[[test]]">[[test]]</a><br>
       </template>
     </template>
   </template>
@@ -119,6 +119,18 @@ found in the LICENSE file.
       async fetchResults (url) {
         const response = await window.fetch(url);
         return response.ok ? await response.json() : {};
+      }
+
+      computeBrowserCount(count) {
+        if (count == 0) return "no browsers";
+        if (count == 1) return "1 browser";
+        if (count > 1) return `${count} browsers`;
+      }
+
+      computeOtherBrowserCount(count) {
+        if (count == 0) return "no other browsers";
+        if (count == 1) return "1 other browser";
+        if (count > 1) return `${count} other browsers`;
       }
     }
 

--- a/webapp/index.yaml
+++ b/webapp/index.yaml
@@ -52,3 +52,8 @@ indexes:
   - name: CreatedAt
     direction: desc
   - name: Revision
+- kind: github.com.w3c.wptdashboard.metrics.FailuresMetadata
+  properties:
+  - name: BrowserName
+  - name: StartTime
+    direction: desc

--- a/webapp/templates/anomalies.html
+++ b/webapp/templates/anomalies.html
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
 <html>
-{{ template "_head.html" }}
+<head>
+  {{ template "_head_common.html" }}
+  <link rel="import" href="/components/anomalies.html">
+</head>
 <body>
 <div id="content">
   {{ template "_header.html" }}
   <div>
-    Interoperability anomalies view coming soon.
+    <wpt-anomalies pass-rate-metadata="{{ .Metadata }}" browser="{{ .Browser }}"></wpt-anomalies>
   </div>
 </div>
 {{ template "_ga.html" }}


### PR DESCRIPTION
Running at https://lukebjerring-interoperability-anomalies-dot-wptdashboard.appspot.com/interop/anomalies

First iteration is a slow-loading, flat list of all tests which pass in some, but not all, browsers, with no browser-specific views.

`/interop/anomalies` (no params) will show a list of anomalies (test that fail in at least one, but not all, browsers).
`/interop/anomalies?browser=[browser]` will show tests that **fail** in that browser, but not in all browsers.