### PR TITLE
Metrics=>GCS: Write data, then update gzip metadata

### DIFF
--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -89,23 +89,27 @@ func (ctx GCSDatastoreContext) Output(id OutputId, metadata interface{},
 	log.Printf("Writing %s to Google Cloud Storage\n", name)
 	gcsData := GCSData{metadata, data}
 	obj := ctx.Bucket.Handle.Object(id.DataLocation.GCSObjectPath)
+	objWriter := obj.NewWriter(ctx.Context)
+	if err := func() error {
+		gzWriter := gzip.NewWriter(objWriter)
+		encoder := json.NewEncoder(gzWriter)
+		if err := encoder.Encode(gcsData); err != nil {
+			return err
+		}
+		gzWriter.Close()
+		return objWriter.Close()
+	}(); err != nil {
+		log.Printf("Error writing %s to Google Cloud Storage: %v\n",
+			name, err)
+		errs = append(errs, err)
+		return nil, make([]interface{}, 0), errs
+	}
 	_, err := obj.Update(ctx.Context, storage.ObjectAttrsToUpdate{
 		ContentEncoding: "gzip",
 	})
 	if err != nil {
 		log.Printf("Error setting new Google Cloud Storage object Content-Encoding to \"gzip\": %v",
 			err)
-		errs = append(errs, err)
-		return nil, make([]interface{}, 0), errs
-	}
-	objWriter := obj.NewWriter(ctx.Context)
-	defer objWriter.Close()
-	gzWriter := gzip.NewWriter(objWriter)
-	defer gzWriter.Close()
-	encoder := json.NewEncoder(gzWriter)
-	if err := encoder.Encode(gcsData); err != nil {
-		log.Printf("Error writing %s to Google Cloud Storage: %v\n",
-			name, err)
 		errs = append(errs, err)
 		return nil, make([]interface{}, 0), errs
 	}

--- a/metrics/storage/storage.go
+++ b/metrics/storage/storage.go
@@ -92,11 +92,12 @@ func (ctx GCSDatastoreContext) Output(id OutputId, metadata interface{},
 	objWriter := obj.NewWriter(ctx.Context)
 	if err := func() error {
 		gzWriter := gzip.NewWriter(objWriter)
+		defer gzWriter.Close()
 		encoder := json.NewEncoder(gzWriter)
 		if err := encoder.Encode(gcsData); err != nil {
+			objWriter.Close()
 			return err
 		}
-		gzWriter.Close()
 		return objWriter.Close()
 	}(); err != nil {
 		log.Printf("Error writing %s to Google Cloud Storage: %v\n",


### PR DESCRIPTION
Without reversing the data-write+metadata-write ordering, the metadata-write fails (and hence metrics data collection fails).