### PR TITLE
Correct the code for relative paths

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -144,7 +144,7 @@ found in the LICENSE file.
             <tr>
               <td>
                 <template is="dom-if" if="{{ node.isDir }}">
-                  <b><a href="{{ node.path }}" on-click="navigate">{{ relativePath(node.path) }}</a></b>
+                  <b><a href="{{ node.path }}" on-click="navigate">{{ relativePath(node.path) }}/</a></b>
                 </template>
                 <template is="dom-if" if="{{ !node.isDir }}">
                   <a href="{{ node.path }}" on-click="navigate">{{ relativePath(node.path) }}</a>
@@ -393,7 +393,8 @@ found in the LICENSE file.
       }
 
       relativePath(path) {
-        return path.replace(this.path + '/', '');
+        const prefix = this.path == '/' ? '/' : this.path + '/';
+        return path.replace(prefix, '');
       }
 
       hasResults(node, testRun) {


### PR DESCRIPTION
Currently, the root / index view is showing items with a leading /, e.g. `/2dcontext` and `/FileAPI`, while nested folders do not lead with a slash. 

This PR corrects the relativePath function, but also adds a _trailing_ slash to non-test-file paths, making folder vs file more obvious (bold isn't that clear.)