### PR TITLE
Ignore populate_dev_data files when deploying

### DIFF
--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -21,3 +21,8 @@ handlers:
 - url: /.*
   script: _go_app
   secure: always
+
+# Don't upload mock-data static files to AppEngine
+skip_files:
+- static/b952881825/
+- static/wptd-metrics/


### PR DESCRIPTION
Currently they break deployment due to their size, and are unused in production.