### PR TITLE
Add deploy helper-script

### DIFF
--- a/git/git-deploy
+++ b/git/git-deploy
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Helper script for using a standardized version flag when deploying.
+
+REPO_DIR="$(dirname "$0")/.."
+source "${REPO_DIR}/util/logging.sh"
+source "${REPO_DIR}/util/path.sh"
+WPTD_PATH=${WPTD_PATH:-$(absdir "${REPO_DIR}")}
+
+usage() {
+  info "Usage: git-deploy [-p] [-h]";
+}
+
+while getopts ':ph' flag; do
+  case "${flag}" in
+    p) PRODUCTION='true' ;;
+    h|*) usage && exit 0;;
+  esac
+done
+
+BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
+USER="$(git remote -v get-url origin | sed -E 's#https?:\/\/github.com\/##' | sed 's#/.*$##')"
+VERSION="${USER}-${BRANCH_NAME}"
+PROMOTE="--no-promote"
+
+if [[ ${PRODUCTION} == 'true' ]]
+then
+  info "Producing production configuration..."
+  if [[ "${USER}" != "w3c" ]]
+  then
+    confirm "Are you sure you want to be deploying a non-w3c repo (${USER})?"
+    if [ "${?}" != "0" ]; then exit "${?}"; fi
+  fi
+  # Use SHA for prod-pushes.
+  VERSION="$(git rev-parse --short HEAD)"
+  PROMOTE="--promote"
+fi
+
+COMMAND="gcloud app deploy ${PROMOTE} --version=${VERSION} ${WPTD_PATH}/webapp"
+
+info "Deploy command:\n${COMMAND}"
+confirm "Execute?"
+if [ "${?}" != "0" ]; then exit "${?}"; fi
+
+info "Executing..."
+${COMMAND}
+exit 0

--- a/git/git-deploy
+++ b/git/git-deploy
@@ -19,7 +19,7 @@ while getopts ':ph' flag; do
 done
 
 BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
-USER="$(git remote -v get-url origin | sed -E 's#https?:\/\/github.com\/##' | sed 's#/.*$##')"
+USER="$(git remote -v get-url origin | sed -E 's#(https?:\/\/|git@)github.com(\/|:)##' | sed 's#/.*$##')"
 VERSION="${USER}-${BRANCH_NAME}"
 PROMOTE="--no-promote"
 


### PR DESCRIPTION
The script simply picks a version-name to pass to AppEngine, which helps with readability, and deleting old versions.

Staging (default):
--version=[Git repo user]-[Git branch name]
Prod (-p):
--version=[Git repo short-SHA]

When deploying with -p, checks that the repo user is w3c; if not, double-checks with the user.