### PR TITLE
Add script for using populate_dev_data.go in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,7 @@ py_deps: $(find . -type f | grep '\.py$' | grep -v '\_pb.py$')
 
 go_deps: $(find .  -type f | grep '\.go$' | grep -v '\.pb.go$')
 	cd $(WPTD_GO_PATH); go get -t ./...
+
+dev_data:
+	cd $(WPTD_GO_PATH)/util; go get -t ./...
+	go run util/populate_dev_data.go

--- a/README.md
+++ b/README.md
@@ -22,23 +22,20 @@ This starts a Docker instance named `wptd-dev-instance`.
 
 ## Running locally
 
-In one terminal, start the web server:
+Once the instance is running, you can fire up the web server in another terminal:
 
 ```sh
 ./util/docker-dev/web_server.sh
 ```
 
 This will build dependencies and start the Google App Engine development server inside `wptd-dev-instance`.
-You'll also need to populate the app datastore with some initial data, using util/populate_dev_data.py.
+
+With the webserver running, you'll also need to populate the app datastore with some initial data. In another terminal,
+execute the script which leverages `util/populate_dev_data.go` by running:
 
 ```sh
-./util/populate_dev_data.py \
-    --server localhost:9999 \
-    --sdk-root /path/to/google-cloud-sdk \
-    --creds ~/Downloads/wptdashboard-creds-file.json
+./util/docker-dev/dev_data.sh
 ```
-
-Further instructions on using the populate util can be found with the --help flag.
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md) for more information on local development.
 

--- a/util/docker-dev/dev_data.sh
+++ b/util/docker-dev/dev_data.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+DOCKER_DIR=$(dirname "$0")
+source "${DOCKER_DIR}/../logging.sh"
+
+# Run util/populate_dev_data.go (via make) in the docker environment.
+
+# This script copies the file found under the $GOOGLE_APPLICATION_CREDENTIALS
+# environment variable across to the docker instance, and sets the instance's
+# same environment variable to point to the copy.
+
+DOCKER_INSTANCE=wptd-dev-instance
+DEFAULT_CREDS_FILE=/home/application_default_credentials.json
+COPY_COMMAND="docker cp ${GOOGLE_APPLICATION_CREDENTIALS} ${DOCKER_INSTANCE}:${DEFAULT_CREDS_FILE}"
+ENVIRONMENT_VAR="-e GOOGLE_APPLICATION_CREDENTIALS=${DEFAULT_CREDS_FILE}"
+
+if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" == "" ]]
+then
+    warn "Environment variable \$GOOGLE_APPLICATION_CREDENTIALS not set."
+    warn "See https://developers.google.com/accounts/docs/application-default-credentials for more information."
+    ENVIRONMENT_VAR=""
+else
+    info "${COPY_COMMAND}"
+    ${COPY_COMMAND}
+fi
+
+docker exec -t -u $(id -u $USER):$(id -g $USER) ${ENVIRONMENT_VAR} ${DOCKER_INSTANCE} make dev_data


### PR DESCRIPTION
Leverages the populate_dev_data.go in docker, to avoid issues (fixes https://github.com/w3c/wptdashboard/issues/378).

For compatibility with docker-external execution, this script leverages the `$GOOGLE_APPLICATION_CREDENTIALS` variable, copying the file into docker.