### PR TITLE
Add path-part component

### DIFF
--- a/webapp/components/path-part.html
+++ b/webapp/components/path-part.html
@@ -1,0 +1,78 @@
+<!--
+Copyright 2017 The WPT Dashboard Project. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+
+<!--
+`<path-part>` is a stateless component for displaying part of a test path.
+-->
+<dom-module id="path-part">
+  <template>
+    <style>
+      a:hover {
+        cursor: pointer;
+        color: #226ff3;
+      }
+      .dir-path {
+        font-weight: bold;
+      }
+    </style>
+
+    <a class$="{{ styleClass }}" href="{{ href }}" on-click="navigate">
+      {{ relativePath }}
+    </a>
+  </template>
+
+  <script>
+    class PathPart extends window.Polymer.Element {
+      static get is() { return 'path-part'; }
+
+      static get properties() {
+        return {
+          path: {
+            type: String
+          },
+          // Domain path-prefix, e.g. '/interop/'
+          prefix: {
+            type: String,
+            default: '/'
+          },
+          isDir: {
+            type: Boolean
+          },
+          relativePath: {
+            type: String,
+            computed: 'computedDisplayableRelativePath()'
+          },
+          href: {
+            type: String,
+            computed: 'computeHref(prefix, path)'
+          },
+          styleClass: {
+            type: String,
+            computed: 'computePathClass()'
+          }
+        };
+      }
+
+      computeHref(prefix, path) {
+        return `${prefix || ''}${path}`;
+      }
+
+      computedDisplayableRelativePath() {
+        const windowPath = window.location.pathname.replace(`${this.prefix || ''}`, '');
+        const pathPrefix = new RegExp(`^${windowPath}${windowPath.endsWith('/') ? '' : '/'}`);
+        return `${this.path.replace(pathPrefix, '')}${this.isDir ? '/' : ''}`;
+      }
+
+      computePathClass() {
+        return this.isDir ? 'dir-path' : 'file-path';
+      }
+    }
+
+    window.customElements.define(PathPart.is, PathPart);
+  </script>
+</dom-module>

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -7,6 +7,7 @@ found in the LICENSE file.
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="path-part.html">
 <link rel="import" href="runs.html">
 <link rel="import" href="test-file-results.html">
 <link rel="import" href="test-run.html">
@@ -32,14 +33,10 @@ found in the LICENSE file.
         padding: 0.5em 0;
         width: 100%;
       }
-      a {
+      path-part {
         text-decoration: none;
         color: #0d5de6;
         font-family: monospace;
-      }
-      a:hover {
-        cursor: pointer;
-        color: #226ff3;
       }
       table {
         width: 100%;
@@ -143,7 +140,7 @@ found in the LICENSE file.
           <template is="dom-repeat" items="{{displayedNodes}}" as="node">
             <tr>
               <td>
-                <a style="{{ relativePathStyle(node) }}" href="{{ node.path }}" on-click="navigate">{{ displayableRelativePath(node) }}</a>
+                <path-part path="{{ node.path }}" is-dir="{{ node.isDir }}"></path-part>
               </td>
 
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">
@@ -383,15 +380,6 @@ found in the LICENSE file.
           // Some shade of red
           return `background-color: hsl(0, 85%, ${luminance}%)`;
         }
-      }
-
-      displayableRelativePath(node) {
-        const prefix = this.path === '/' ? '/' : `${this.path}/`;
-        return `${node.path.replace(prefix, '')}${node.isDir ? '/' : ''}`;
-      }
-
-      relativePathStyle(node) {
-        return node.isDir ? 'font-weight: bold;' : '';
       }
 
       hasResults(node, testRun) {


### PR DESCRIPTION
Step towards a consolidated URI path treatment on wpt.fyi for https://github.com/w3c/wptdashboard/issues/374.

Running at https://lukebjerring-path-part-dot-wptdashboard.appspot.com

path-part takes an optional prefix, where `/interop` will we used for interop, and eventually we will pick a prefix for the current default view (to be future-friendly - see the issue for more context).