### PR TITLE
Fix bug with stale path-part

### DIFF
--- a/webapp/components/path-part.html
+++ b/webapp/components/path-part.html
@@ -21,7 +21,7 @@ found in the LICENSE file.
       }
     </style>
 
-    <a class$="{{ styleClass }}" href="{{ href }}" on-click="navigate">
+    <a class$="{{ styleClass }}" href="{{ href }}" onclick="{{ navigate }}">
       {{ relativePath }}
     </a>
   </template>
@@ -43,9 +43,12 @@ found in the LICENSE file.
           isDir: {
             type: Boolean
           },
+          navigate: {
+            type: Function
+          },
           relativePath: {
             type: String,
-            computed: 'computedDisplayableRelativePath()'
+            computed: 'computedDisplayableRelativePath(path)'
           },
           href: {
             type: String,
@@ -62,10 +65,10 @@ found in the LICENSE file.
         return `${prefix || ''}${path}`;
       }
 
-      computedDisplayableRelativePath() {
+      computedDisplayableRelativePath(path) {
         const windowPath = window.location.pathname.replace(`${this.prefix || ''}`, '');
         const pathPrefix = new RegExp(`^${windowPath}${windowPath.endsWith('/') ? '' : '/'}`);
-        return `${this.path.replace(pathPrefix, '')}${this.isDir ? '/' : ''}`;
+        return `${path.replace(pathPrefix, '')}${this.isDir ? '/' : ''}`;
       }
 
       computePathClass() {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -140,7 +140,7 @@ found in the LICENSE file.
           <template is="dom-repeat" items="{{displayedNodes}}" as="node">
             <tr>
               <td>
-                <path-part path="{{ node.path }}" is-dir="{{ node.isDir }}"></path-part>
+                <path-part path="{{ node.path }}" is-dir="{{ node.isDir }}" navigate="{{ bindNavigate() }}"></path-part>
               </td>
 
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">
@@ -320,6 +320,10 @@ found in the LICENSE file.
         return `${browser_name}-${browser_version}-${os_name}-${os_version}`;
       }
 
+      bindNavigate() {
+        return this.navigate.bind(this);
+      }
+      
       navigate(event) {
         event.preventDefault();
         let path = event.target.pathname.replace(/(.+)(\/)$/, '$1');


### PR DESCRIPTION
This PR fixes 2 issues with the path-part:
1) `navigate` was dropped in translation, so pages are fully reloading.
2) The `path-part` displayed text (relative path) is not updated when `navigate` occurs.

Forwarding the `navigate` event requires binding `this` correctly (or, changing the function).
For the Polymer property to automagically update, we need the compute function to depend on the `path` property (since it can't tell from the function body that it depends on `this.path`.