### PR TITLE
Fix interop path-part navigate + stale class

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -173,7 +173,7 @@ found in the LICENSE file.
       <template is="dom-repeat" items="{{ metrics.data }}" as="node">
         <tr>
           <td>
-            <path-part path="{{ node.dir }}" is-dir="{{ !computePathIsATestFile(node.dir) }}" prefix="/interop"></path-part>
+            <path-part path="{{ node.dir }}" is-dir="{{ !computePathIsATestFile(node.dir) }}" prefix="/interop" navigate="{{ bindNavigate() }}"></path-part>
           </td>
 
           <template is="dom-repeat" items="{{node.pass_rates}}" as="passRate">
@@ -282,6 +282,10 @@ found in the LICENSE file.
           path: pathSoFar
         }
       });
+    }
+
+    bindNavigate () {
+      return this.navigate.bind(this);
     }
 
     navigate (event) {

--- a/webapp/components/path-part.html
+++ b/webapp/components/path-part.html
@@ -56,7 +56,7 @@ found in the LICENSE file.
           },
           styleClass: {
             type: String,
-            computed: 'computePathClass()'
+            computed: 'computePathClass(isDir)'
           }
         };
       }
@@ -71,8 +71,8 @@ found in the LICENSE file.
         return `${path.replace(pathPrefix, '')}${this.isDir ? '/' : ''}`;
       }
 
-      computePathClass() {
-        return this.isDir ? 'dir-path' : 'file-path';
+      computePathClass(isDir) {
+        return isDir ? 'dir-path' : 'file-path';
       }
     }
 


### PR DESCRIPTION
Same bug as https://github.com/w3c/wptdashboard/pull/405 - I didn't have a chance to tweak https://github.com/w3c/wptdashboard/pull/404 to include the same fix.