### PR TITLE
Vendor protoc-gen-bq-schema

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/github.com/GoogleCloudPlatform/protoc-gen-bq-schema"]
+	path = vendor/github.com/GoogleCloudPlatform/protoc-gen-bq-schema
+	url = https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -93,7 +93,8 @@ RUN curl -L -o "protoc.zip" "https://github.com/google/protobuf/releases/downloa
 
 # Install protobuf BigQuery schema generator
 ENV BQ_SCHEMA_PATH="github.com/GoogleCloudPlatform/protoc-gen-bq-schema"
-WORKDIR ${WPTD_PATH}/vendor/${BQ_SCHEMA_PATH}
+RUN go get ${BQ_SCHEMA_PATH}
+WORKDIR ${GOPATH}/src/${BQ_SCHEMA_PATH}
 # Copy executable to bin dir
 RUN make && \
     cp "bin/protoc-gen-bq-schema" /usr/local/bin/ && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -93,8 +93,7 @@ RUN curl -L -o "protoc.zip" "https://github.com/google/protobuf/releases/downloa
 
 # Install protobuf BigQuery schema generator
 ENV BQ_SCHEMA_PATH="github.com/GoogleCloudPlatform/protoc-gen-bq-schema"
-RUN go get ${BQ_SCHEMA_PATH}
-WORKDIR ${GOPATH}/src/${BQ_SCHEMA_PATH}
+WORKDIR ${WPTD_PATH}/vendor/${BQ_SCHEMA_PATH}
 # Copy executable to bin dir
 RUN make && \
     cp "bin/protoc-gen-bq-schema" /usr/local/bin/ && \

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,14 @@ SHELL := /bin/bash
 WPTD_PATH ?= /home/jenkins/wptdashboard
 WPTD_GO_PATH ?= $(GOPATH)/src/github.com/w3c/wptdashboard
 
+BQ_LIB_REPO ?= github.com/GoogleCloudPlatform/protoc-gen-bq-schema
 PB_LIB_DIR ?= ../protobuf/src
-PB_BQ_LIB_DIR ?= ../protoc-gen-bq-schema
+PB_BQ_LIB_DIR ?= $(WPTD_PATH)/vendor/$(BQ_LIB_REPO)
 PB_LOCAL_LIB_DIR ?= protos
 PB_BQ_OUT_DIR ?= bq-schema
 PB_PY_OUT_DIR ?= run/protos
 PB_GO_OUT_DIR ?= generated
-PB_GO_PKG_MAP ?= Mbq_table_name.proto=github.com/GoogleCloudPlatform/protoc-gen-bq-schema/protos
+PB_GO_PKG_MAP ?= Mbq_table_name.proto=$(BQ_LIB_REPO)/protos
 
 PROTOS=$(wildcard $(PB_LOCAL_LIB_DIR)/*.proto)
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ PB_GO_PKG_MAP ?= Mbq_table_name.proto=$(BQ_LIB_REPO)/protos
 
 PROTOS=$(wildcard $(PB_LOCAL_LIB_DIR)/*.proto)
 
+GO_FILES := $(wildcard $(WPTD_PATH)/**/*.go)
+GO_FILES := $(filter-out $(wildcard $(WPTD_PATH)/generated/**/*.go), $(GO_FILES))
+GO_FILES := $(filter-out $(wildcard $(WPTD_PATH)/vendor/**/*.go), $(GO_FILES))
+
 build: go_deps proto
 
 test: py_test go_test
@@ -47,9 +51,9 @@ py_test: py_proto py_deps
 	python -m unittest discover -p '*_test.py'
 
 go_lint: go_deps
-	cd $(WPTD_GO_PATH); golint -set_exit_status
+	cd $(WPTD_GO_PATH); golint -set_exit_status $(GO_FILES)
 	# Print differences between current/gofmt'd output, check empty.
-	cd $(WPTD_GO_PATH); ! gofmt -d . 2>&1 | read
+	cd $(WPTD_GO_PATH); ! gofmt -d $(GO_FILES) 2>&1 | read
 
 go_test: go_deps
 	cd $(WPTD_GO_PATH); go test -v ./...


### PR DESCRIPTION
We (barely) depend on this (small) external lib, and it's breaking us whenever it changes, so I'm plonking it in the `vendor` path. 

Some reading to explain vendor path: https://golang.org/cmd/go/#hdr-Vendor_Directories