### PR TITLE
Remove superflous banner

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -95,16 +95,6 @@ found in the LICENSE file.
       </div>
     </section>
 
-    <section class="caveat">
-      Data below are intended for web platform implementers and do not contain
-      useful metrics for evaluation or comparison of web platform features.
-      Each browser listed here is currently tested at its latest stable
-      release. See <a
-        href="https://github.com/w3c/wptdashboard/issues/109">#109</a> and <a
-        href="https://github.com/w3c/wptdashboard/issues/112">#112</a> for
-      discussion on testing pre-release versions.
-    </section>
-
     <template is="dom-if" if="{{ pathIsATestFile }}">
       <div class="links">
         <ul>


### PR DESCRIPTION
Recent changes in the surrounding interface have obviated the need for the caveat in this banner element.