### PR TITLE
Implement workaround for bug in WPT CLI

### DIFF
--- a/run/run.py
+++ b/run/run.py
@@ -216,7 +216,15 @@ def main(platform_id, platform, args, config):
     full_report = {'results': []}
     for name in glob.glob('%s/*.json' % abs_report_chunks_path):
         with open(name) as f:
-            partial_report = json.load(f)
+            # The WPT CLI is known to produce invalid JSON files in some
+            # circumstances. These cases represent test executions with zero
+            # results. Tolerate this condition and interpret accordingly.
+            #
+            # https://github.com/w3c/web-platform-tests/issues/9481
+            try:
+                partial_report = json.load(f)
+            except ValueError:
+                continue
 
         full_report['results'].extend(partial_report['results'])
 

--- a/run/run_integration_test.py
+++ b/run/run_integration_test.py
@@ -646,6 +646,82 @@ class TestRun2(unittest.TestCase):
             expected_output_dir + [platform_id, 'js', 'bitwise-and.html']
         )
 
+    def test_empty_results(self):
+        platform_id = 'chrome-64.0-linux'
+
+        def git(*args):
+            if 'log' in args:
+                return {'stdout': 'deadbeef'}
+
+        self.remote_control.add_handler('git', git)
+        self.remote_control.add_handler(
+            'chrome', lambda *_: {'stdout': 'Chromium 64.0.3282.119'}
+        )
+        self.write_browsers_manifest({
+            platform_id: {
+                'initially_loaded': False,
+                'currently_run': False,
+                'browser_name': 'chrome',
+                'browser_version': '64.0',
+                'os_name': platform.system().lower(),
+                'os_version': '*'
+            }
+        })
+        self.remote_control.add_handler('wpt', self.cmd_wpt)
+        self.wpt_log_file_name = 'wptd-%s-%s-report.log' % (
+            'deadbeef', platform_id
+        )
+        self.wpt_log_contents = [
+            '',
+            '',
+            '',
+            json.dumps({'results': [
+                {
+                    'test': '/js/with-statement.html',
+                    'status': 'OK',
+                    'message': None,
+                    'subtests': [
+                        {'status': 'PASS', 'message': None, 'name': 'first'},
+                        {'status': 'FAIL', 'message': 'bad', 'name': 'second'}
+                    ]
+                },
+                {
+                    'test': '/js/isNaN.html',
+                    'status': 'OK',
+                    'message': None,
+                    'subtests': [
+                        {'status': 'PASS', 'message': None, 'name': 'first'},
+                        {'status': 'FAIL', 'message': 'bad', 'name': 'second'},
+                        {'status': 'PASS', 'message': None, 'name': 'third'}
+                    ]
+                }
+            ]})
+        ]
+
+        returncode, stdout, stderr = self.run_py([
+            platform_id, '--total-chunks', '2'
+        ])
+
+        self.assertEquals(returncode, 0, stderr)
+
+        actual_output_dir = [log_dir, 'deadbeef']
+        expected_output_dir = [
+            here, 'expected_output', 'simple_report-1', 'deadbeef'
+        ]
+
+        self.assertJsonMatch(
+            actual_output_dir + ['%s-summary.json.gz' % platform_id],
+            expected_output_dir + ['%s-summary.json.gz' % platform_id]
+        )
+        self.assertJsonMatch(
+            actual_output_dir + [platform_id, 'js', 'with-statement.html'],
+            expected_output_dir + [platform_id, 'js', 'with-statement.html']
+        )
+        self.assertJsonMatch(
+            actual_output_dir + [platform_id, 'js', 'isNaN.html'],
+            expected_output_dir + [platform_id, 'js', 'isNaN.html']
+        )
+
     def test_os_name_mismatch(self):
         platform_id = 'chrome-63.0-linux'
 


### PR DESCRIPTION
@rwaldron This is a fix that I originally implemented as part of gh-467. I've decided to backport it to `master` for a few reasons:

- I have new evidence that the WPT CLI bug is currently preventing us from benefiting from the "retry" heuristic implemented in gh-426
- gh-467 is intended to implement an unrelated feature and includes a lot of change. It's review should not be hastened by our desire to fix the bug

So I recommend that we focus on this patch first. (Rebasing gh-467 will be trivial.)