### PR TITLE
Load browser config. data during initialization

### DIFF
--- a/webapp/util.go
+++ b/webapp/util.go
@@ -12,59 +12,39 @@ import (
 	models "github.com/w3c/wptdashboard/shared"
 )
 
-var browsers map[string]models.Browser
-
-// No 'set' type in Go, so use map instead.
-var browserNames map[string]bool
-var browserNamesAlphabetical []string
-
-// GetBrowsers loads, parses and returns the set of names of browsers
-// which are to be included (flagged as initially_loaded in the JSON).
-func GetBrowsers() (map[string]models.Browser, error) {
-	if browsers != nil {
-		return browsers, nil
-	}
-	var bytes []byte
-	var err error
-	if bytes, err = ioutil.ReadFile("browsers.json"); err != nil {
-		return nil, err
-	}
-
-	if err = json.Unmarshal(bytes, &browsers); err != nil {
-		return nil, err
-	}
-	return browsers, nil
-}
+var browserNames, browserNamesAlphabetical = loadBrowsers()
 
 // GetBrowserNames returns an alphabetically-ordered array of the names
-// of the browsers returned by GetBrowsers.
+// of the browsers which are to be included (flagged as initially_loaded in the
+// JSON).
 func GetBrowserNames() ([]string, error) {
-	if browserNamesAlphabetical == nil {
-		if err := loadBrowserNames(); err != nil {
-			return nil, err
-		}
-	}
 	return browserNamesAlphabetical, nil
 }
 
 // IsBrowserName determines whether the given name string is a valid browser name.
 // Used for validating user-input params for browsers.
 func IsBrowserName(name string) bool {
-	if browserNames == nil {
-		if err := loadBrowserNames(); err != nil {
-			return false
-		}
-	}
 	_, ok := browserNames[name]
 	return ok
 }
 
-func loadBrowserNames() error {
+// loadBrowsers loads, parses and returns the set of names of browsers which
+// are to be included (flagged as initially_loaded in the JSON).
+func loadBrowsers() (map[string]bool, []string) {
 	var browsers map[string]models.Browser
 	var err error
-	if browsers, err = GetBrowsers(); err != nil {
-		return err
+	var bytes []byte
+	var browserNames map[string]bool
+	var browserNamesAlphabetical []string
+
+	if bytes, err = ioutil.ReadFile("browsers.json"); err != nil {
+		panic(err)
 	}
+
+	if err = json.Unmarshal(bytes, &browsers); err != nil {
+		panic(err)
+	}
+
 	browserNames = make(map[string]bool)
 	for _, browser := range browsers {
 		if browser.InitiallyLoaded {
@@ -73,7 +53,8 @@ func loadBrowserNames() error {
 		}
 	}
 	sort.Strings(browserNamesAlphabetical)
-	return nil
+
+	return browserNames, browserNamesAlphabetical
 }
 
 func abs(x int) int {


### PR DESCRIPTION
Previously, data describing the available browsers was not loaded until
the web server handled a request which required it. Subsequent requests
were intended to re-use the result of this operation, persisted as
global application state.

That strategy was susceptible to a race condition: if the initial
request that triggered data loading was quickly followed by a similar
request, the loading logic would be executed a second time, and the
resuting in-memory representation would include two entries for each
available browser.

Re-factor the internals to load the browser data at module
initialization time (e.g. before any requests are received).