### PR TITLE
Configure TravisCI builds to report test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,10 @@ install: |
   docker exec -u 0:0 "${DOCKER_INSTANCE}" chown -R $(id -u $USER):$(id -g $USER) /home/jenkins
 
 script:
-  - docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}"
+  - |
+    if [ "${MAKE_TEST_TARGET}" != "" ]; then
+      docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}"
+    fi
   - |
     if [ "${WCT}" == "1" ]; then
       cd webapp && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,12 +75,12 @@ install: |
 
   docker exec -u 0:0 "${DOCKER_INSTANCE}" chown -R $(id -u $USER):$(id -g $USER) /home/jenkins
 
-script: |
-  docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}"
-
-  if [ "${WCT}" == "1" ]; then
-    cd webapp && npm test
-  fi
+script:
+  - docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}"
+  - |
+    if [ "${WCT}" == "1" ]; then
+      cd webapp && npm test
+    fi
 
 after_script:
   - docker stop "${DOCKER_INSTANCE}"


### PR DESCRIPTION
The TravisCI documentation reads [1]:

> When one of the build commands returns a non-zero exit code, the Travis CI build runs the subsequent commands as well, and accumulates the build result.

Express disparate test commands as distinct items in an array within the TravisCI "script" configuration, ensuring that any failure causes the build to be labeled as "failing" (as opposed to only recognizing the result of the final command).

[1] https://docs.travis-ci.com/user/customizing-the-build/

This depends on gh-480