### PR TITLE
Always use the firefox binary in running.ini

### DIFF
--- a/run/run.py
+++ b/run/run.py
@@ -177,7 +177,7 @@ def main(platform_id, platform, args, config):
             if platform['browser_name'] == 'chrome':
                 command.extend(['--binary', browser_binary])
             if platform['browser_name'] == 'firefox':
-                command.extend(['--binary', browser_binary])                
+                command.extend(['--binary', browser_binary])
                 # we no longer want to download a firefox binary
                 command.append('--yes')
                 # this actually refers to 'say yes to everything'

--- a/run/run.py
+++ b/run/run.py
@@ -177,7 +177,8 @@ def main(platform_id, platform, args, config):
             if platform['browser_name'] == 'chrome':
                 command.extend(['--binary', browser_binary])
             if platform['browser_name'] == 'firefox':
-                command.extend(['--install-browser', '--yes'])
+                command.extend(['--binary', browser_binary])
+                # we no longer want to download a firefox binary
                 command.append('--certutil-binary=certutil')
                 # temporary fix to allow WebRTC tests to call getUserMedia
                 command.extend([
@@ -251,7 +252,7 @@ def main(platform_id, platform, args, config):
 
     if platform['browser_name'] == 'firefox':
         logger.info('Verifying installed firefox matches platform ID')
-        firefox_path = '%s/_venv/firefox/firefox' % config['wpt_path']
+        firefox_path = config['firefox_binary']
         verify_browser_binary_version(platform, firefox_path)
 
     logger.info('Creating summary of results')

--- a/run/run.py
+++ b/run/run.py
@@ -177,8 +177,11 @@ def main(platform_id, platform, args, config):
             if platform['browser_name'] == 'chrome':
                 command.extend(['--binary', browser_binary])
             if platform['browser_name'] == 'firefox':
-                command.extend(['--binary', browser_binary])
+                command.extend(['--binary', browser_binary])                
                 # we no longer want to download a firefox binary
+                command.append('--yes')
+                # this actually refers to 'say yes to everything'
+                # and not installing a browser, as previously written
                 command.append('--certutil-binary=certutil')
                 # temporary fix to allow WebRTC tests to call getUserMedia
                 command.extend([

--- a/webapp/browsers.json
+++ b/webapp/browsers.json
@@ -1,15 +1,15 @@
 {
     "chrome-64.0-linux": {
-        "initially_loaded": false,
-        "currently_run": false,
+        "initially_loaded": true,
+        "currently_run": true,
         "browser_name": "chrome",
         "browser_version": "64.0",
         "os_name": "linux",
         "os_version": "*"
     },
     "chrome-63.0-linux": {
-        "initially_loaded": true,
-        "currently_run": true,
+        "initially_loaded": false,
+        "currently_run": false,
         "browser_name": "chrome",
         "browser_version": "63.0",
         "os_name": "linux",
@@ -39,9 +39,17 @@
         "os_name": "linux",
         "os_version": "*"
     },
-    "firefox-58.0-linux": {
+    "firefox-59.0-linux": {
         "initially_loaded": true,
         "currently_run": true,
+        "browser_name": "firefox",
+        "browser_version": "59.0",
+        "os_name": "linux",
+        "os_version": "*"
+    },
+    "firefox-58.0-linux": {
+        "initially_loaded": false,
+        "currently_run": false,
         "browser_name": "firefox",
         "browser_version": "58.0",
         "os_name": "linux",

--- a/webapp/browsers.json
+++ b/webapp/browsers.json
@@ -48,8 +48,8 @@
         "os_version": "*"
     },
     "firefox-57.0-linux": {
-        "initially_loaded": true,
-        "currently_run": true,
+        "initially_loaded": false,
+        "currently_run": false,
         "browser_name": "firefox",
         "browser_version": "57.0",
         "os_name": "linux",

--- a/webapp/browsers.json
+++ b/webapp/browsers.json
@@ -39,6 +39,14 @@
         "os_name": "linux",
         "os_version": "*"
     },
+    "firefox-58.0-linux": {
+        "initially_loaded": true,
+        "currently_run": true,
+        "browser_name": "firefox",
+        "browser_version": "58.0",
+        "os_name": "linux",
+        "os_version": "*"
+    },
     "firefox-57.0-linux": {
         "initially_loaded": true,
         "currently_run": true,


### PR DESCRIPTION
This also includes an update to `browsers.json` which adds Firefox 58.0