### PR TITLE
run.py: handle cases where WPT "raw log" is empty

### DIFF
--- a/run/run.py
+++ b/run/run.py
@@ -389,6 +389,8 @@ def get_expected_tests(filename):
 
             return data.get('tests').get('default')
 
+    return []
+
 
 def get_commit_details(mainargs, config, logger):
     wpt_sha = ''


### PR DESCRIPTION
This may occur when the WPT CLI process fails due to factors other than failing tests (e.g. a misconfigured system or a network outage).

Testing this fix required extending the test code a bit. I'm submitting that in a dedicated commit to help delineate things.