### PR TITLE
add command line flags for webrtc

### DIFF
--- a/run/run.py
+++ b/run/run.py
@@ -180,7 +180,6 @@ def main(platform_id, platform, args, config):
                 # temporary fix to allow WebRTC tests to call getUserMedia
                 command.extend(['--binary-arg=--use-fake-ui-for-media-stream'])
                 command.extend(['--binary-arg=--use-fake-device-for-media-stream'])
-                print(command)
             if platform['browser_name'] == 'firefox':
                 command.extend(['--install-browser', '--yes'])
                 command.append('--certutil-binary=certutil')

--- a/run/run.py
+++ b/run/run.py
@@ -179,9 +179,8 @@ def main(platform_id, platform, args, config):
 
                 # temporary fix to allow WebRTC tests to call getUserMedia
                 command.extend(
-                    ['--binary-arg=--use-fake-ui-for-media-stream'])
-                command.extend(
-                    ['--binary-arg=--use-fake-device-for-media-stream'])
+                    ['--binary-arg=--use-fake-ui-for-media-stream',
+                     '--binary-arg=--use-fake-device-for-media-stream'])
             if platform['browser_name'] == 'firefox':
                 command.extend(['--install-browser', '--yes'])
                 command.append('--certutil-binary=certutil')

--- a/run/run.py
+++ b/run/run.py
@@ -178,8 +178,10 @@ def main(platform_id, platform, args, config):
                 command.extend(['--binary', browser_binary])
 
                 # temporary fix to allow WebRTC tests to call getUserMedia
-                command.extend(['--binary-arg=--use-fake-ui-for-media-stream'])
-                command.extend(['--binary-arg=--use-fake-device-for-media-stream'])
+                command.extend(
+                    ['--binary-arg=--use-fake-ui-for-media-stream'])
+                command.extend(
+                    ['--binary-arg=--use-fake-device-for-media-stream'])
             if platform['browser_name'] == 'firefox':
                 command.extend(['--install-browser', '--yes'])
                 command.append('--certutil-binary=certutil')

--- a/run/run.py
+++ b/run/run.py
@@ -176,6 +176,11 @@ def main(platform_id, platform, args, config):
                 command.insert(5, args.path)
             if platform['browser_name'] == 'chrome':
                 command.extend(['--binary', browser_binary])
+
+                # temporary fix to allow WebRTC tests to call getUserMedia
+                command.extend(['--binary-arg=--use-fake-ui-for-media-stream'])
+                command.extend(['--binary-arg=--use-fake-device-for-media-stream'])
+                print(command)
             if platform['browser_name'] == 'firefox':
                 command.extend(['--install-browser', '--yes'])
                 command.append('--certutil-binary=certutil')


### PR DESCRIPTION
This is intended as a temporary fix to allow the webrtc tests in chrome to call getUserMedia without failing out.